### PR TITLE
Update workbench url

### DIFF
--- a/projects/test-harness/.env
+++ b/projects/test-harness/.env
@@ -1,1 +1,1 @@
-APP_DIRECTORY_CONFIG_FILE_PATH=./src/finos-app-directory.config.json
+APP_DIRECTORY_CONFIG_FILE_PATH=./src/test-harness.config.json

--- a/projects/test-harness/src/test-harness.config.json
+++ b/projects/test-harness/src/test-harness.config.json
@@ -474,7 +474,7 @@
             "appId": "fdc3-workbench",
             "type": "web",
             "details": {
-                "url": "http://localhost:4001/toolbox/fdc3-workbench/"
+                "url": "https://fdc3.finos.org/toolbox/fdc3-workbench/"
             }
         }
     ]


### PR DESCRIPTION
The publically hosted workbench now works within our test harness