### PR TITLE
Upgrade to @finos/fdc3 alpha.3 from kite9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2110,6 +2110,76 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/@finos/fdc3": {
+            "version": "2.2.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@finos/fdc3/-/fdc3-2.2.0-alpha.3.tgz",
+            "integrity": "sha512-undYUA1eBVUY2Tg3nYtfJak2zpRtJ6X8u30vtPCDFuVky/m+hyWJE6VcD7tVCnzAeyfyL/+PLcRabxjqaEmlDg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@finos/fdc3-context": "2.2.0-alpha.3",
+                "@finos/fdc3-get-agent": "2.2.0-alpha.3",
+                "@finos/fdc3-schema": "2.2.0-alpha.3",
+                "@finos/fdc3-standard": "2.2.0-alpha.3"
+            }
+        },
+        "node_modules/@finos/fdc3-agent-proxy": {
+            "version": "2.2.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@finos/fdc3-agent-proxy/-/fdc3-agent-proxy-2.2.0-alpha.3.tgz",
+            "integrity": "sha512-CGpL2VzEaxpQCtC3wvZgJMKUXAENZxNb4rUfH/Cm1qzfpZn7b0CjefBLD2gwLJOJaFiDbsjYuzWe6aNhoNV1rg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@finos/fdc3-standard": "2.2.0-alpha.3"
+            }
+        },
+        "node_modules/@finos/fdc3-context": {
+            "version": "2.2.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@finos/fdc3-context/-/fdc3-context-2.2.0-alpha.3.tgz",
+            "integrity": "sha512-Ilg4zuKX6I1PJFwhmoVnj0L0t0J2Q7xdwe5WvlFa2t21xP+I0RL8XMhMHhS+IsmbmwNUUyNqbTlaqtLsTnlAkw==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@finos/fdc3-get-agent": {
+            "version": "2.2.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@finos/fdc3-get-agent/-/fdc3-get-agent-2.2.0-alpha.3.tgz",
+            "integrity": "sha512-jf1Wb4S+H4aiH838cdb2zFPexyGBa5Ld+rBkhEKxm0ITLfEtb6fOeMehhF3FGtNWhLS8DwUav8AcNYLeX7lg/Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@finos/fdc3-agent-proxy": "2.2.0-alpha.3",
+                "@finos/fdc3-context": "2.2.0-alpha.3",
+                "@finos/fdc3-schema": "2.2.0-alpha.3",
+                "@finos/fdc3-standard": "2.2.0-alpha.3",
+                "@types/uuid": "^10.0.0",
+                "uuid": "^9.0.1"
+            }
+        },
+        "node_modules/@finos/fdc3-get-agent/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@finos/fdc3-schema": {
+            "version": "2.2.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@finos/fdc3-schema/-/fdc3-schema-2.2.0-alpha.3.tgz",
+            "integrity": "sha512-heLtB9cGI+1K7NaJekElWOQ/sRN6vfidQ33XQqNUwjI+pkNw/ZVY/6t1q/Bk5zQj8L53nfMH+a3w0tI/CLbnNQ==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@finos/fdc3-standard": {
+            "version": "2.2.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@finos/fdc3-standard/-/fdc3-standard-2.2.0-alpha.3.tgz",
+            "integrity": "sha512-TAPb7o8BBdasw66sXFHIlhQU8MYpB4Pi3Q36J1AC1NB73+0JrXhapla2/q36r9K199wtFZGjfKASJiXVMvWNyA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@finos/fdc3-context": "2.2.0-alpha.3",
+                "@finos/fdc3-schema": "2.2.0-alpha.3"
+            }
+        },
         "node_modules/@gerrit0/mini-shiki": {
             "version": "1.27.2",
             "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.27.2.tgz",
@@ -2725,76 +2795,6 @@
             },
             "peerDependencies": {
                 "tslib": "2"
-            }
-        },
-        "node_modules/@kite9/fdc3": {
-            "version": "2.2.0-beta.29",
-            "resolved": "https://registry.npmjs.org/@kite9/fdc3/-/fdc3-2.2.0-beta.29.tgz",
-            "integrity": "sha512-rwSLtZCzce9MxD9XeABI/oLRzvKdR1kc34Hn8E4KzfYzEhENuN0Xq4rFM/V9ywehXEX0s2sg7JDMMJHsUaEkuw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@kite9/fdc3-context": "2.2.0-beta.29",
-                "@kite9/fdc3-get-agent": "2.2.0-beta.29",
-                "@kite9/fdc3-schema": "2.2.0-beta.29",
-                "@kite9/fdc3-standard": "2.2.0-beta.29"
-            }
-        },
-        "node_modules/@kite9/fdc3-agent-proxy": {
-            "version": "2.2.0-beta.29",
-            "resolved": "https://registry.npmjs.org/@kite9/fdc3-agent-proxy/-/fdc3-agent-proxy-2.2.0-beta.29.tgz",
-            "integrity": "sha512-M/ijMFSBsVMRlxbK5OSN1xscD8SpoZyT5cVORUE1RFShvvzXJ/YPUdEzVkH5cIeS5o7f7nbe9F0Tg0dM+o9lPw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@kite9/fdc3-standard": "2.2.0-beta.29"
-            }
-        },
-        "node_modules/@kite9/fdc3-context": {
-            "version": "2.2.0-beta.29",
-            "resolved": "https://registry.npmjs.org/@kite9/fdc3-context/-/fdc3-context-2.2.0-beta.29.tgz",
-            "integrity": "sha512-4BaUIBqLNTCsC3IOQdbuc3E8wo3efx6SH+F4DsvzAF3eW2Yb+qTf9u2qwg/m5j7T/ZTgk0KN086tCC0Jrk1saA==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@kite9/fdc3-get-agent": {
-            "version": "2.2.0-beta.29",
-            "resolved": "https://registry.npmjs.org/@kite9/fdc3-get-agent/-/fdc3-get-agent-2.2.0-beta.29.tgz",
-            "integrity": "sha512-QkoHPW3dCUhUFsOuspPVnCzumEKULh9wqeBq10fpjVUtgosS1/Dgl5J/vWK2LLkedi90agbODGPyUnR0P59UsA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@kite9/fdc3-agent-proxy": "2.2.0-beta.29",
-                "@kite9/fdc3-context": "2.2.0-beta.29",
-                "@kite9/fdc3-schema": "2.2.0-beta.29",
-                "@kite9/fdc3-standard": "2.2.0-beta.29",
-                "@types/uuid": "^10.0.0",
-                "uuid": "^9.0.1"
-            }
-        },
-        "node_modules/@kite9/fdc3-get-agent/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
-        "node_modules/@kite9/fdc3-schema": {
-            "version": "2.2.0-beta.29",
-            "resolved": "https://registry.npmjs.org/@kite9/fdc3-schema/-/fdc3-schema-2.2.0-beta.29.tgz",
-            "integrity": "sha512-n2PinAO7sM9825LARTQld9izc6pVV0v2IM+bxtpnni+qT/8t6FTremovKfuq54T74Wi47pC0TriBH+o/GNpZEA==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@kite9/fdc3-standard": {
-            "version": "2.2.0-beta.29",
-            "resolved": "https://registry.npmjs.org/@kite9/fdc3-standard/-/fdc3-standard-2.2.0-beta.29.tgz",
-            "integrity": "sha512-sxXJNOtZ3yre4+2qOEXPYVf/RRVnrITMKew8G9E0LWN2fgsEiuar0OdIlJzki68Nt3j/CfmrpmF5QEg7Cz/K/w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@kite9/fdc3-context": "2.2.0-beta.29",
-                "@kite9/fdc3-schema": "2.2.0-beta.29"
             }
         },
         "node_modules/@leichtgewicht/ip-codec": {
@@ -19538,7 +19538,7 @@
             "version": "0.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@kite9/fdc3": "^2.2.0-beta.25"
+                "@finos/fdc3": "^2.2.0-alpha.3"
             },
             "devDependencies": {
                 "@babel/preset-env": "^7.25.4",
@@ -19644,10 +19644,12 @@
             "name": "@morgan-stanley/fdc3-web-messaging-provider",
             "version": "0.2.0",
             "license": "Apache-2.0",
+            "dependencies": {
+                "@finos/fdc3": "^2.2.0-alpha.3"
+            },
             "devDependencies": {
                 "@babel/preset-env": "^7.25.4",
                 "@babel/preset-typescript": "^7.24.7",
-                "@kite9/fdc3": "^2.2.0-beta.25",
                 "@morgan-stanley/fdc3-web": "^0.2.0",
                 "@morgan-stanley/ts-mocking-bird": "^1.2.0",
                 "@types/eslint": "^8.56.10",
@@ -19683,7 +19685,6 @@
                 "webpack-cli": "^5.1.4"
             },
             "peerDependencies": {
-                "@kite9/fdc3": "^2.2.0-beta.25",
                 "@morgan-stanley/fdc3-web": "^0.1.4"
             }
         },
@@ -19706,7 +19707,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@kite9/fdc3": "^2.2.0-beta.25",
+                "@finos/fdc3": "^2.2.0-alpha.3",
                 "@morgan-stanley/fdc3-web": "^0.2.0",
                 "@morgan-stanley/fdc3-web-messaging-provider": "^0.2.0",
                 "@morgan-stanley/fdc3-web-ui-provider": "^0.2.0",
@@ -19752,6 +19753,7 @@
             "version": "0.2.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@finos/fdc3": "^2.2.0-alpha.3",
                 "lit": "^3.2.0",
                 "lit-element": "^4.1.0"
             },
@@ -19759,7 +19761,6 @@
                 "@babel/plugin-proposal-decorators": "^7.24.7",
                 "@babel/preset-env": "^7.25.4",
                 "@babel/preset-typescript": "^7.24.7",
-                "@kite9/fdc3": "^2.2.0-beta.25",
                 "@morgan-stanley/fdc3-web": "^0.2.0",
                 "@morgan-stanley/ts-mocking-bird": "^1.2.0",
                 "@types/eslint": "^8.56.10",
@@ -19789,7 +19790,6 @@
                 "typescript": "~5.6.2"
             },
             "peerDependencies": {
-                "@kite9/fdc3": "^2.2.0-beta.25",
                 "@morgan-stanley/fdc3-web": "^0.1.4"
             }
         },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "author": "Morgan Stanley",
     "scripts": {
-        "clean": "nx run-many -t clean --excludeTaskDependencies && rimraf build ../packages ../install",
+        "clean": "nx run-many -t clean --excludeTaskDependencies && rimraf build tmp",
         "lint-fix": "nx run-many -t lint-fix --excludeTaskDependencies",
         "lint": "nx run-many -t lint --excludeTaskDependencies",
         "build": "nx run-many -t build",

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -50,9 +50,6 @@
         "typedoc": "^0.26.8",
         "typescript": "~5.6.2"
     },
-    "dependencies": {
-        "@kite9/fdc3": "^2.2.0-beta.25"
-    },
     "nx": {
         "targets": {
             "build": {
@@ -82,5 +79,8 @@
                 }
             }
         }
+    },
+    "dependencies": {
+        "@finos/fdc3": "^2.2.0-alpha.3"
     }
 }

--- a/projects/lib/src/agent/desktop-agent-proxy.spec.ts
+++ b/projects/lib/src/agent/desktop-agent-proxy.spec.ts
@@ -24,8 +24,8 @@ import type {
     IntentResult,
     Listener,
     PrivateChannel,
-} from '@kite9/fdc3';
-import { OpenError, ResolveError } from '@kite9/fdc3';
+} from '@finos/fdc3';
+import { OpenError, ResolveError } from '@finos/fdc3';
 import {
     IMocked,
     Mock,

--- a/projects/lib/src/agent/desktop-agent-proxy.ts
+++ b/projects/lib/src/agent/desktop-agent-proxy.ts
@@ -28,7 +28,7 @@ import {
     IntentResult,
     Listener,
     PrivateChannel,
-} from '@kite9/fdc3';
+} from '@finos/fdc3';
 import { ChannelFactory, Channels } from '../channel';
 import { FullyQualifiedAppIdentifier, IProxyMessagingProvider } from '../contracts';
 import {

--- a/projects/lib/src/agent/desktop-agent.factory.ts
+++ b/projects/lib/src/agent/desktop-agent.factory.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { AgentError, type DesktopAgent } from '@kite9/fdc3';
+import { AgentError, type DesktopAgent } from '@finos/fdc3';
 import { AppDirectory } from '../app-directory';
 import { DefaultResolver } from '../app-directory/app-resolver.default';
 import { ChannelFactory } from '../channel';

--- a/projects/lib/src/agent/desktop-agent.spec.ts
+++ b/projects/lib/src/agent/desktop-agent.spec.ts
@@ -18,7 +18,7 @@ import {
     type Listener,
     OpenError,
     ResolveError,
-} from '@kite9/fdc3';
+} from '@finos/fdc3';
 import {
     IMocked,
     Mock,
@@ -1085,7 +1085,7 @@ describe(`${DesktopAgentImpl.name} (desktop-agent)`, () => {
 
                 await postRequestMessage(getInfoMessage, source);
 
-                const version = dependencies['@kite9/fdc3'];
+                const version = dependencies['@finos/fdc3'];
                 const expectedVersion = (
                     version.indexOf('^') !== -1
                         ? version.slice(version.indexOf('^') + 1)
@@ -2163,7 +2163,7 @@ describe(`${DesktopAgentImpl.name} (desktop-agent)`, () => {
                     },
                     payload: {
                         privateChannelId: mockedChannelId,
-                        listenerType: 'onDisconnect',
+                        listenerType: 'disconnect',
                     },
                     type: 'privateChannelAddEventListenerRequest',
                 };

--- a/projects/lib/src/agent/desktop-agent.ts
+++ b/projects/lib/src/agent/desktop-agent.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { BrowserTypes, DesktopAgent, ImplementationMetadata, Intent, OpenError, ResolveError } from '@kite9/fdc3';
+import { BrowserTypes, DesktopAgent, ImplementationMetadata, Intent, OpenError, ResolveError } from '@finos/fdc3';
 import { AppDirectory } from '../app-directory';
 import { AppDirectoryApplication } from '../app-directory.contracts';
 import { ChannelFactory } from '../channel';

--- a/projects/lib/src/agent/fallback-open-strategy.spec.ts
+++ b/projects/lib/src/agent/fallback-open-strategy.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { BrowserTypes, DesktopAgent, OpenError } from '@kite9/fdc3';
+import { BrowserTypes, DesktopAgent, OpenError } from '@finos/fdc3';
 import {
     any,
     IMocked,

--- a/projects/lib/src/agent/fallback-open-strategy.ts
+++ b/projects/lib/src/agent/fallback-open-strategy.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { OpenError } from '@kite9/fdc3';
+import { OpenError } from '@finos/fdc3';
 import { IOpenApplicationStrategy, OpenApplicationStrategyParams } from '../contracts';
 import { isWebAppDetails, subscribeToConnectionAttemptUuids } from '../helpers';
 

--- a/projects/lib/src/app-directory.contracts.ts
+++ b/projects/lib/src/app-directory.contracts.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { Icon, Image } from '@kite9/fdc3';
+import { Icon, Image } from '@finos/fdc3';
 
 export type AppDirectoryApplicationType = 'web' | 'native' | 'citrix' | 'onlineNative' | 'other';
 export type WebAppDetails = { url: string };

--- a/projects/lib/src/app-directory/app-resolver.default.spec.ts
+++ b/projects/lib/src/app-directory/app-resolver.default.spec.ts
@@ -8,8 +8,8 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { AppIdentifier, AppIntent, DesktopAgent, Intent } from '@kite9/fdc3';
-import { ResolveError } from '@kite9/fdc3';
+import type { AppIdentifier, AppIntent, DesktopAgent, Intent } from '@finos/fdc3';
+import { ResolveError } from '@finos/fdc3';
 import { IMocked, Mock, setupFunction } from '@morgan-stanley/ts-mocking-bird';
 import { ResolveForContextPayload, ResolveForIntentPayload } from '../contracts';
 import { DefaultResolver } from './app-resolver.default';

--- a/projects/lib/src/app-directory/app-resolver.default.ts
+++ b/projects/lib/src/app-directory/app-resolver.default.ts
@@ -8,8 +8,8 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { AppIdentifier, DesktopAgent } from '@kite9/fdc3';
-import { ResolveError } from '@kite9/fdc3';
+import type { AppIdentifier, DesktopAgent } from '@finos/fdc3';
+import { ResolveError } from '@finos/fdc3';
 import {
     FullyQualifiedAppIdentifier,
     IAppResolver,

--- a/projects/lib/src/app-directory/directory.spec.ts
+++ b/projects/lib/src/app-directory/directory.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { type AppIdentifier, type AppIntent, type Contact, type Context, type Intent, ResolveError } from '@kite9/fdc3';
+import { type AppIdentifier, type AppIntent, type Contact, type Context, type Intent, ResolveError } from '@finos/fdc3';
 import { IMocked, Mock, proxyJestModule, registerMock, setupFunction } from '@morgan-stanley/ts-mocking-bird';
 import { AppDirectoryApplication, AppDirectoryApplicationType, WebAppDetails } from '../app-directory.contracts';
 import {

--- a/projects/lib/src/app-directory/directory.ts
+++ b/projects/lib/src/app-directory/directory.ts
@@ -16,7 +16,7 @@ import {
     type Intent,
     OpenError,
     ResolveError,
-} from '@kite9/fdc3';
+} from '@finos/fdc3';
 import { AppDirectoryApplication } from '../app-directory.contracts';
 import {
     FullyQualifiedAppId,

--- a/projects/lib/src/channel/channel-message-handler.spec.ts
+++ b/projects/lib/src/channel/channel-message-handler.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { BrowserTypes, ChannelError, Contact, Context, EventHandler, Listener, PrivateChannel } from '@kite9/fdc3';
+import { BrowserTypes, ChannelError, Contact, Context, EventHandler, Listener, PrivateChannel } from '@finos/fdc3';
 import {
     IMocked,
     Mock,
@@ -550,7 +550,7 @@ describe(`${ChannelMessageHandler.name} (channel-message-handler)`, () => {
                     source,
                 },
                 payload: {
-                    listenerType: 'onDisconnect',
+                    listenerType: 'disconnect',
                     privateChannelId: 'mocked-generated-Uuid',
                 },
                 type: 'privateChannelAddEventListenerRequest',
@@ -583,7 +583,7 @@ describe(`${ChannelMessageHandler.name} (channel-message-handler)`, () => {
                     source: sourceTwo,
                 },
                 payload: {
-                    listenerType: 'onDisconnect',
+                    listenerType: 'disconnect',
                     privateChannelId: 'mocked-generated-Uuid',
                 },
                 type: 'privateChannelAddEventListenerRequest',
@@ -621,7 +621,7 @@ describe(`${ChannelMessageHandler.name} (channel-message-handler)`, () => {
                     source,
                 },
                 payload: {
-                    listenerType: 'onDisconnect',
+                    listenerType: 'disconnect',
                     privateChannelId: mockedGeneratedUuid,
                 },
                 type: 'privateChannelAddEventListenerRequest',
@@ -686,7 +686,7 @@ describe(`${ChannelMessageHandler.name} (channel-message-handler)`, () => {
                     source,
                 },
                 payload: {
-                    listenerType: 'onAddContextListener',
+                    listenerType: 'addContextListener',
                     privateChannelId: mockedGeneratedUuid,
                 },
                 type: 'privateChannelAddEventListenerRequest',
@@ -773,7 +773,7 @@ describe(`${ChannelMessageHandler.name} (channel-message-handler)`, () => {
                     source,
                 },
                 payload: {
-                    listenerType: 'onDisconnect',
+                    listenerType: 'disconnect',
                     privateChannelId: 'mocked-generated-Uuid',
                 },
                 type: 'privateChannelAddEventListenerRequest',
@@ -1028,7 +1028,7 @@ describe(`${ChannelMessageHandler.name} (channel-message-handler)`, () => {
 
             mockCreatePrivateChannel(instance);
 
-            mockPrivateChannelAddEventListener('onAddContextListener', mockedGeneratedUuid, source, instance);
+            mockPrivateChannelAddEventListener('addContextListener', mockedGeneratedUuid, source, instance);
 
             const addContextListenerRequest: BrowserTypes.AddContextListenerRequest = {
                 meta: {
@@ -1179,7 +1179,7 @@ describe(`${ChannelMessageHandler.name} (channel-message-handler)`, () => {
 
             mockCreatePrivateChannel(instance);
 
-            mockPrivateChannelAddEventListener('onUnsubscribe', mockedGeneratedUuid, source, instance);
+            mockPrivateChannelAddEventListener('unsubscribe', mockedGeneratedUuid, source, instance);
 
             const addContextListenerRequest: BrowserTypes.AddContextListenerRequest = {
                 meta: {
@@ -1791,7 +1791,7 @@ describe(`${ChannelMessageHandler.name} (channel-message-handler)`, () => {
 
             mockAddContextListener(mockedGeneratedUuid, null, source, instance);
 
-            mockPrivateChannelAddEventListener('onUnsubscribe', mockedGeneratedUuid, source, instance);
+            mockPrivateChannelAddEventListener('unsubscribe', mockedGeneratedUuid, source, instance);
 
             const privateChannelDisconnectMessage: BrowserTypes.PrivateChannelDisconnectRequest = {
                 meta: {
@@ -1828,7 +1828,7 @@ describe(`${ChannelMessageHandler.name} (channel-message-handler)`, () => {
 
             instance.addToPrivateChannelAllowedList(mockedGeneratedUuid, sourceTwo);
 
-            mockPrivateChannelAddEventListener('onDisconnect', mockedGeneratedUuid, sourceTwo, instance);
+            mockPrivateChannelAddEventListener('disconnect', mockedGeneratedUuid, sourceTwo, instance);
 
             const privateChannelDisconnectMessage: BrowserTypes.PrivateChannelDisconnectRequest = {
                 meta: {
@@ -2022,7 +2022,7 @@ describe(`${ChannelMessageHandler.name} (channel-message-handler)`, () => {
     }
 
     function mockPrivateChannelAddEventListener(
-        listenerType: BrowserTypes.PrivateChannelEventListenerTypes,
+        listenerType: BrowserTypes.PrivateChannelEventType,
         privateChannelId: string,
         source: FullyQualifiedAppIdentifier,
         instance: ChannelMessageHandler,

--- a/projects/lib/src/channel/channel-message-handler.ts
+++ b/projects/lib/src/channel/channel-message-handler.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { BrowserTypes, ChannelError, Context, PrivateChannelEventTypes } from '@kite9/fdc3';
+import { BrowserTypes, ChannelError, Context, PrivateChannelEventTypes } from '@finos/fdc3';
 import { EventListenerLookup, FullyQualifiedAppIdentifier } from '../contracts';
 import { IRootPublisher } from '../contracts.internal';
 import {
@@ -239,7 +239,10 @@ export class ChannelMessageHandler {
             return;
         }
 
-        const eventType = convertToPrivateChannelEventTypes(requestMessage.payload.listenerType);
+        const eventType =
+            requestMessage.payload.listenerType === null
+                ? 'allEvents'
+                : convertToPrivateChannelEventTypes(requestMessage.payload.listenerType);
         const listeners =
             this.privateChannelEventListeners[eventType] ?? (this.privateChannelEventListeners[eventType] = []);
 

--- a/projects/lib/src/channel/channel.contracts.ts
+++ b/projects/lib/src/channel/channel.contracts.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { AppIdentifier, BrowserTypes, Channel, DesktopAgent, PrivateChannel } from '@kite9/fdc3';
+import type { AppIdentifier, BrowserTypes, Channel, DesktopAgent, PrivateChannel } from '@finos/fdc3';
 import { IProxyMessagingProvider } from '../contracts';
 
 /**

--- a/projects/lib/src/channel/channel.private.spec.ts
+++ b/projects/lib/src/channel/channel.private.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { BrowserTypes, EventHandler, Listener, PrivateChannel as FDC3PrivateChannel } from '@kite9/fdc3';
+import type { BrowserTypes, EventHandler, Listener, PrivateChannel as FDC3PrivateChannel } from '@finos/fdc3';
 import { IMocked, Mock, proxyJestModule, registerMock, setupFunction } from '@morgan-stanley/ts-mocking-bird';
 import {
     EventMessage,
@@ -312,7 +312,7 @@ describe(`${PrivateChannel.name} (channel.private)`, () => {
             const expectedMessage: BrowserTypes.PrivateChannelAddEventListenerRequest = {
                 meta: createExpectedRequestMeta(),
                 payload: {
-                    listenerType: 'onDisconnect',
+                    listenerType: 'disconnect',
                     privateChannelId: instance.id,
                 },
                 type: 'privateChannelAddEventListenerRequest',

--- a/projects/lib/src/channel/channel.private.ts
+++ b/projects/lib/src/channel/channel.private.ts
@@ -14,7 +14,7 @@ import type {
     Listener,
     PrivateChannel as FDC3PrivateChannel,
     PrivateChannelEventTypes,
-} from '@kite9/fdc3';
+} from '@finos/fdc3';
 import { FullyQualifiedAppIdentifier, IProxyMessagingProvider } from '../contracts';
 import {
     createRequestMessage,

--- a/projects/lib/src/channel/channel.public.spec.ts
+++ b/projects/lib/src/channel/channel.public.spec.ts
@@ -8,8 +8,8 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { BrowserTypes, Channel, Contact, Context, ContextHandler, Listener } from '@kite9/fdc3';
-import { ChannelError } from '@kite9/fdc3';
+import type { BrowserTypes, Channel, Contact, Context, ContextHandler, Listener } from '@finos/fdc3';
+import { ChannelError } from '@finos/fdc3';
 import { IMocked, Mock, proxyJestModule, registerMock, setupFunction, toBe } from '@morgan-stanley/ts-mocking-bird';
 import {
     EventMessage,

--- a/projects/lib/src/channel/channel.public.ts
+++ b/projects/lib/src/channel/channel.public.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { BrowserTypes, Channel, Context, ContextHandler, DisplayMetadata, Listener } from '@kite9/fdc3';
+import type { BrowserTypes, Channel, Context, ContextHandler, DisplayMetadata, Listener } from '@finos/fdc3';
 import { FullyQualifiedAppIdentifier, IProxyMessagingProvider } from '../contracts';
 import { createRequestMessage, isBroadcastResponse, resolveContextType } from '../helpers';
 import { MessagingBase } from '../messaging';

--- a/projects/lib/src/channel/channels.factory.ts
+++ b/projects/lib/src/channel/channels.factory.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { BrowserTypes, Channel, PrivateChannel as FDC3PrivateChannel } from '@kite9/fdc3';
+import type { BrowserTypes, Channel, PrivateChannel as FDC3PrivateChannel } from '@finos/fdc3';
 import { FullyQualifiedAppIdentifier, IProxyMessagingProvider } from '../contracts';
 import { IRootPublisher } from '../contracts.internal';
 import { IChannelFactory } from './channel.contracts';

--- a/projects/lib/src/channel/channels.spec.ts
+++ b/projects/lib/src/channel/channels.spec.ts
@@ -16,8 +16,8 @@ import type {
     DisplayMetadata,
     Listener,
     PrivateChannel,
-} from '@kite9/fdc3';
-import { ChannelError } from '@kite9/fdc3';
+} from '@finos/fdc3';
+import { ChannelError } from '@finos/fdc3';
 import {
     IMocked,
     Mock,

--- a/projects/lib/src/channel/channels.ts
+++ b/projects/lib/src/channel/channels.ts
@@ -17,7 +17,7 @@ import type {
     DesktopAgent,
     Listener,
     PrivateChannel as FDC3PrivateChannel,
-} from '@kite9/fdc3';
+} from '@finos/fdc3';
 import { FullyQualifiedAppIdentifier, IProxyMessagingProvider } from '../contracts';
 import {
     createRequestMessage,

--- a/projects/lib/src/channel/context-listener.spec.ts
+++ b/projects/lib/src/channel/context-listener.spec.ts
@@ -17,8 +17,8 @@ import type {
     DisplayMetadata,
     Listener,
     PrivateChannel,
-} from '@kite9/fdc3';
-import { ChannelError } from '@kite9/fdc3';
+} from '@finos/fdc3';
+import { ChannelError } from '@finos/fdc3';
 import {
     IMocked,
     Mock,

--- a/projects/lib/src/channel/context-listener.ts
+++ b/projects/lib/src/channel/context-listener.ts
@@ -16,7 +16,7 @@ import type {
     ContextMetadata,
     ContextType,
     Listener,
-} from '@kite9/fdc3';
+} from '@finos/fdc3';
 import { FullyQualifiedAppIdentifier, IProxyMessagingProvider } from '../contracts';
 import {
     createRequestMessage,

--- a/projects/lib/src/channel/default-channels.ts
+++ b/projects/lib/src/channel/default-channels.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { BrowserTypes } from '@kite9/fdc3';
+import type { BrowserTypes } from '@finos/fdc3';
 
 export const recommendedChannels: BrowserTypes.Channel[] = [
     {

--- a/projects/lib/src/contracts.ts
+++ b/projects/lib/src/contracts.ts
@@ -18,7 +18,7 @@ import type {
     FDC3EventTypes,
     Intent,
     PrivateChannelEvent,
-} from '@kite9/fdc3';
+} from '@finos/fdc3';
 import { AppDirectoryApplication } from './app-directory.contracts';
 
 export type RequestMessage =

--- a/projects/lib/src/get-agent/get-agent.spec.ts
+++ b/projects/lib/src/get-agent/get-agent.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { DesktopAgent, GetAgentParams } from '@kite9/fdc3';
+import { DesktopAgent, GetAgentParams } from '@finos/fdc3';
 import { Mock, setupFunction } from '@morgan-stanley/ts-mocking-bird';
 import { getAgent, resetCachedPromise } from './get-agent';
 

--- a/projects/lib/src/get-agent/get-agent.ts
+++ b/projects/lib/src/get-agent/get-agent.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { AgentError, BrowserTypes, DesktopAgent, GetAgentParams, GetAgentType } from '@kite9/fdc3';
+import { AgentError, BrowserTypes, DesktopAgent, GetAgentParams, GetAgentType } from '@finos/fdc3';
 import { DesktopAgentFactory } from '../agent';
 import { DEFAULT_AGENT_DISCOVERY_TIMEOUT, FDC3_READY_EVENT } from '../constants';
 import { IProxyMessagingProvider } from '../contracts';
@@ -84,7 +84,7 @@ const getAgentImpl: GetAgentType = async (params?: GetAgentParams): Promise<Desk
     log(`getAgent called with params:`, 'debug', params);
 
     const existingAgent = await Promise.race([
-        waitForPreloadAgent(params?.timeout),
+        waitForPreloadAgent(params?.timeoutMs),
         waitForProxyAgent(params?.identityUrl),
     ]);
 

--- a/projects/lib/src/helpers/app-directory-applications.helper.ts
+++ b/projects/lib/src/helpers/app-directory-applications.helper.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { AppMetadata, BrowserTypes, ImplementationMetadata } from '@kite9/fdc3';
+import { AppMetadata, BrowserTypes, ImplementationMetadata } from '@finos/fdc3';
 import { AppDirectoryApplication } from '../app-directory.contracts';
 import { FDC3_PROVIDER, FDC3_VERSION } from '../constants';
 import { FullyQualifiedAppIdentifier } from '../contracts';

--- a/projects/lib/src/helpers/app-identity.helper.spec.ts
+++ b/projects/lib/src/helpers/app-identity.helper.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { AppIdentifier } from '@kite9/fdc3';
+import type { AppIdentifier } from '@finos/fdc3';
 import { appInstanceEquals, resolveAppIdentifier } from './app-identity.helper';
 
 describe(`app-identity.helper`, () => {

--- a/projects/lib/src/helpers/app-identity.helper.ts
+++ b/projects/lib/src/helpers/app-identity.helper.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { AppIdentifier } from '@kite9/fdc3';
+import type { AppIdentifier } from '@finos/fdc3';
 import { FullyQualifiedAppIdentifier } from '../contracts';
 
 /**

--- a/projects/lib/src/helpers/context.helper.ts
+++ b/projects/lib/src/helpers/context.helper.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { ContextHandler, ContextType } from '@kite9/fdc3';
+import type { ContextHandler, ContextType } from '@finos/fdc3';
 
 /**
  * Converts implementation addContextListener parameters to those required by fdc3 addContextListener method

--- a/projects/lib/src/helpers/event-type.helper.ts
+++ b/projects/lib/src/helpers/event-type.helper.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { BrowserTypes, FDC3EventTypes, PrivateChannelEventTypes } from '@kite9/fdc3';
+import type { BrowserTypes, FDC3EventTypes, PrivateChannelEventTypes } from '@finos/fdc3';
 import { EventListenerKey } from '../contracts';
 
 type PrivateChannelEventMessageTypes = Extract<
@@ -31,17 +31,17 @@ export function convertToEventListenerIndex(type: 'USER_CHANNEL_CHANGED' | null)
 }
 
 export function convertToPrivateChannelEventTypes(
-    type: BrowserTypes.PrivateChannelEventListenerTypes | PrivateChannelEventMessageTypes,
+    type: BrowserTypes.PrivateChannelEventType | PrivateChannelEventMessageTypes,
 ): PrivateChannelEventTypes {
     switch (type) {
         case 'privateChannelOnAddContextListenerEvent':
-        case 'onAddContextListener':
+        case 'addContextListener':
             return 'addContextListener';
         case 'privateChannelOnDisconnectEvent':
-        case 'onDisconnect':
+        case 'disconnect':
             return 'disconnect';
         case 'privateChannelOnUnsubscribeEvent':
-        case 'onUnsubscribe':
+        case 'unsubscribe':
             return 'unsubscribe';
     }
 }
@@ -61,13 +61,13 @@ export function convertToPrivateChannelEventMessageTypes(
 
 export function convertToPrivateChannelEventListenerTypes(
     type: PrivateChannelEventTypes,
-): BrowserTypes.PrivateChannelEventListenerTypes {
+): BrowserTypes.PrivateChannelEventType {
     switch (type) {
         case 'addContextListener':
-            return 'onAddContextListener';
+            return 'addContextListener';
         case 'disconnect':
-            return 'onDisconnect';
+            return 'disconnect';
         case 'unsubscribe':
-            return 'onUnsubscribe';
+            return 'unsubscribe';
     }
 }

--- a/projects/lib/src/helpers/finos-type-predicate.helper.ts
+++ b/projects/lib/src/helpers/finos-type-predicate.helper.ts
@@ -11,7 +11,7 @@
 /* istanbul ignore file */
 // we hope these functions will get added to @finos/fdc3 so we can remove these implementations
 
-import type { BrowserTypes, PrivateChannel, PrivateChannelEventTypes } from '@kite9/fdc3';
+import type { BrowserTypes, PrivateChannel, PrivateChannelEventTypes } from '@finos/fdc3';
 
 /* istanbul ignore next */
 export function isRequestMessageType(value: any): boolean {

--- a/projects/lib/src/helpers/messages.helper.spec.ts
+++ b/projects/lib/src/helpers/messages.helper.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { BrowserTypes } from '@kite9/fdc3';
+import { BrowserTypes } from '@finos/fdc3';
 import { IMocked, Mock, proxyJestModule, registerMock, setupFunction } from '@morgan-stanley/ts-mocking-bird';
 import { FullyQualifiedAppIdentifier, RequestMessage } from '../contracts';
 import { createEvent, createRequestMessage, createResponseMessage } from './messages.helper';

--- a/projects/lib/src/helpers/messages.helper.ts
+++ b/projects/lib/src/helpers/messages.helper.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { BrowserTypes } from '@kite9/fdc3';
+import { BrowserTypes } from '@finos/fdc3';
 import { FDC3_VERSION } from '../constants';
 import { FullyQualifiedAppIdentifier, RequestMessage } from '../contracts';
 import { isWCPHelloMessage } from './finos-type-predicate.helper';

--- a/projects/lib/src/helpers/type-predicate.helper.ts
+++ b/projects/lib/src/helpers/type-predicate.helper.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { BrowserTypes, Context } from '@kite9/fdc3';
+import { BrowserTypes, Context } from '@finos/fdc3';
 import { WebAppDetails } from '../app-directory.contracts';
 import { FullyQualifiedAppId, FullyQualifiedAppIdentifier, IRootOutgoingMessageEnvelope } from '../contracts';
 

--- a/projects/lib/src/messaging-provider/default-root-messaging-provider.spec.ts
+++ b/projects/lib/src/messaging-provider/default-root-messaging-provider.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { BrowserTypes } from '@kite9/fdc3';
+import { BrowserTypes } from '@finos/fdc3';
 import {
     any,
     IMocked,

--- a/projects/lib/src/messaging/messaging.base.ts
+++ b/projects/lib/src/messaging/messaging.base.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { BrowserTypes } from '@kite9/fdc3';
+import type { BrowserTypes } from '@finos/fdc3';
 import {
     FullyQualifiedAppIdentifier,
     HandshakeMessage,

--- a/projects/lib/src/messaging/root-message-publisher.spec.ts
+++ b/projects/lib/src/messaging/root-message-publisher.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { BrowserTypes } from '@kite9/fdc3';
+import { BrowserTypes } from '@finos/fdc3';
 import {
     IMocked,
     Mock,

--- a/projects/lib/src/messaging/root-message-publisher.ts
+++ b/projects/lib/src/messaging/root-message-publisher.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { BrowserTypes } from '@kite9/fdc3';
+import { BrowserTypes } from '@finos/fdc3';
 import { AppDirectory } from '../app-directory';
 import { AppDirectoryApplication } from '../app-directory.contracts';
 import {

--- a/projects/messaging-provider/package.json
+++ b/projects/messaging-provider/package.json
@@ -23,9 +23,8 @@
     "devDependencies": {
         "@babel/preset-env": "^7.25.4",
         "@babel/preset-typescript": "^7.24.7",
-        "@kite9/fdc3": "^2.2.0-beta.25",
-        "@morgan-stanley/ts-mocking-bird": "^1.2.0",
         "@morgan-stanley/fdc3-web": "^0.2.0",
+        "@morgan-stanley/ts-mocking-bird": "^1.2.0",
         "@types/eslint": "^8.56.10",
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.0",
@@ -59,10 +58,8 @@
         "webpack-cli": "^5.1.4"
     },
     "peerDependencies": {
-        "@morgan-stanley/fdc3-web": "^0.1.4",
-        "@kite9/fdc3": "^2.2.0-beta.25"
+        "@morgan-stanley/fdc3-web": "^0.1.4"
     },
-    "dependencies": {},
     "nx": {
         "targets": {
             "build:relay": {
@@ -100,5 +97,8 @@
                 }
             }
         }
+    },
+    "dependencies": {
+        "@finos/fdc3": "^2.2.0-alpha.3"
     }
 }

--- a/projects/messaging-provider/src/iframe-messaging-provider.spec.ts
+++ b/projects/messaging-provider/src/iframe-messaging-provider.spec.ts
@@ -9,7 +9,7 @@
  * and limitations under the License. */
 
 /* eslint @typescript-eslint/no-var-requires: "off" */
-import type { BrowserTypes } from '@kite9/fdc3';
+import type { BrowserTypes } from '@finos/fdc3';
 import { IProxyOutgoingMessageEnvelope } from '@morgan-stanley/fdc3-web';
 import * as fdc3lib from '@morgan-stanley/fdc3-web';
 import { Mock, registerMock, reset, setupFunction } from '@morgan-stanley/ts-mocking-bird';
@@ -158,15 +158,24 @@ describe('IframeMessagingProvider', () => {
         // Mock the behavior of the iframe loading and the handshake
         mockIframeLoadedListener();
         mockedMessageChannel.port1.onmessage?.({
-            data: <BrowserTypes.IframeHandshake>{ type: 'iframeHandshake', payload: { fdc3Version: '2.2' } },
+            data: <BrowserTypes.WebConnectionProtocol3Handshake>{
+                type: 'WCP3Handshake',
+                payload: { fdc3Version: '2.2.0' },
+            },
         } as any as MessageEvent);
         await relayInitialized;
 
         // Assert
         expect(mockedMessageChannel.port1.postMessage).toHaveBeenCalledWith({
-            type: 'iframeHello',
+            type: 'WCP1Hello',
+            meta: {
+                connectionAttemptUuid: expect.any(String),
+                timestamp: expect.any(Date),
+            },
             payload: {
-                implementationDetails: 'iframe-relay',
+                actualUrl: 'http://localhost/',
+                fdc3Version: '2.2.0',
+                identityUrl: 'http://localhost/',
             },
         });
     });
@@ -192,15 +201,24 @@ describe('IframeMessagingProvider', () => {
         // Mock the behavior of the iframe loading and the handshake
         mockIframeLoadedListener();
         mockedMessageChannel.port1.onmessage?.({
-            data: <BrowserTypes.IframeHandshake>{ type: 'iframeHandshake', payload: { fdc3Version: '2.2' } },
+            data: <BrowserTypes.WebConnectionProtocol3Handshake>{
+                type: 'WCP3Handshake',
+                payload: { fdc3Version: '2.2.0' },
+            },
         } as any as MessageEvent);
         await relayInitialized;
 
         // Assert
         expect(mockedMessageChannel.port1.postMessage).toHaveBeenCalledWith({
-            type: 'iframeHello',
+            type: 'WCP1Hello',
+            meta: {
+                connectionAttemptUuid: expect.any(String),
+                timestamp: expect.any(Date),
+            },
             payload: {
-                implementationDetails: 'iframe-relay',
+                actualUrl: 'http://localhost/',
+                fdc3Version: '2.2.0',
+                identityUrl: 'http://localhost/',
             },
         });
     });
@@ -252,7 +270,10 @@ describe('IframeMessagingProvider', () => {
             const relayInitialized = iframeMessagingProvider.initializeRelay();
             mockIframeLoadedListener();
             mockedMessageChannel.port1.onmessage?.({
-                data: <BrowserTypes.IframeHandshake>{ type: 'iframeHandshake', payload: { fdc3Version: '2.2' } },
+                data: <BrowserTypes.WebConnectionProtocol3Handshake>{
+                    type: 'WCP3Handshake',
+                    payload: { fdc3Version: '2.2.0' },
+                },
             } as any as MessageEvent);
             await relayInitialized;
         });
@@ -325,7 +346,7 @@ describe('IframeMessagingProvider', () => {
 
             // Assert
             expect(mockedConsole.log).toHaveBeenCalledWith(
-                'Relay connected to iframe with implementation details: 2.2',
+                'Relay connected to iframe with implementation details: 2.2.0',
             );
             expect(source.postMessage).toHaveBeenCalledWith(
                 {

--- a/projects/messaging-provider/src/iframe-messaging-provider.ts
+++ b/projects/messaging-provider/src/iframe-messaging-provider.ts
@@ -8,9 +8,10 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { BrowserTypes } from '@kite9/fdc3';
+import type { BrowserTypes } from '@finos/fdc3';
 import {
     discoverProxyCandidates,
+    generateHelloMessage,
     generateUUID,
     IProxyIncomingMessageEnvelope,
     IProxyMessagingProvider,
@@ -158,12 +159,8 @@ export class IframeMessagingProvider implements IProxyMessagingProvider {
         this.messageChannel.port1.onmessage = (...args) => {
             this.onMessage.call(this, ...args, resolve);
         };
-        this.messageChannel.port1.postMessage(<BrowserTypes.IframeHello>{
-            type: 'iframeHello',
-            payload: {
-                implementationDetails: 'iframe-relay',
-            },
-        });
+        const helloMessage = generateHelloMessage();
+        this.messageChannel.port1.postMessage(helloMessage);
 
         this.firstLoadIframe = false;
     }
@@ -172,11 +169,11 @@ export class IframeMessagingProvider implements IProxyMessagingProvider {
      * Handles messages received from the iframe channel adapter.
      */
     private onMessage(event: MessageEvent, resolve: (value: void | PromiseLike<void>) => void): void {
-        if (event.data.type === 'iframeHandshake') {
+        if (event.data.type === 'WCP3Handshake') {
             this.relayInitializeTimeout && clearTimeout(this.relayInitializeTimeout);
             this.relayConnected = true;
             this.consoleRef.log(
-                `Relay connected to iframe with implementation details: ${(<BrowserTypes.IframeHandshake>event.data).payload.fdc3Version}`,
+                `Relay connected to iframe with implementation details: ${(<BrowserTypes.WebConnectionProtocol3Handshake>event.data).payload.fdc3Version}`,
             );
             resolve();
         } else {

--- a/projects/messaging-provider/src/relay/iframe-messaging-provider-relay.spec.ts
+++ b/projects/messaging-provider/src/relay/iframe-messaging-provider-relay.spec.ts
@@ -72,15 +72,27 @@ describe('IframeRelay', () => {
         } as any as MessageEvent);
         mockedMessagePort.onmessage?.({
             data: {
-                type: 'iframeHello',
+                type: 'WCP1Hello',
+                meta: {
+                    connectionAttemptUuid: 'mocked-uuid',
+                },
+                payload: {
+                    fdc3Version: '2.2.0',
+                },
             },
         } as any as MessageEvent);
 
         // Assert
         expect(mockedMessagePort.postMessage).toHaveBeenCalledWith({
-            type: 'iframeHandshake',
+            type: 'WCP3Handshake',
+            meta: {
+                connectionAttemptUuid: 'mocked-uuid',
+                timestamp: expect.any(Date),
+            },
             payload: {
-                fdc3Version: '2.2',
+                channelSelectorUrl: false,
+                intentResolverUrl: false,
+                fdc3Version: '2.2.0',
             },
         });
         expect(mockedMessagePort.onmessage).toBeDefined();

--- a/projects/messaging-provider/src/root-window-messaging-provider.spec.ts
+++ b/projects/messaging-provider/src/root-window-messaging-provider.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { BrowserTypes } from '@kite9/fdc3';
+import type { BrowserTypes } from '@finos/fdc3';
 import {
     FullyQualifiedAppIdentifier,
     IRootIncomingMessageEnvelope,

--- a/projects/test-harness/package.json
+++ b/projects/test-harness/package.json
@@ -51,7 +51,7 @@
         "webpack-dev-server": "^5.1.0"
     },
     "dependencies": {
-        "@kite9/fdc3": "^2.2.0-beta.25",
+        "@finos/fdc3": "^2.2.0-alpha.3",
         "@morgan-stanley/fdc3-web": "^0.2.0",
         "@morgan-stanley/fdc3-web-messaging-provider": "^0.2.0",
         "@morgan-stanley/fdc3-web-ui-provider": "^0.2.0",

--- a/projects/test-harness/src/contracts.ts
+++ b/projects/test-harness/src/contracts.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { AppIdentifier, Context } from '@kite9/fdc3';
+import type { AppIdentifier, Context } from '@finos/fdc3';
 import { AppDirectoryApplication, FullyQualifiedAppIdentifier, WebAppDetails } from '@morgan-stanley/fdc3-web';
 
 export interface AddApp {

--- a/projects/test-harness/src/default-app/default-app.ts
+++ b/projects/test-harness/src/default-app/default-app.ts
@@ -21,7 +21,7 @@ import type {
     IntentResult,
     PrivateChannel as FDC3PrivateChannel,
     PrivateChannelEventTypes,
-} from '@kite9/fdc3';
+} from '@finos/fdc3';
 import {
     AppDirectoryApplication,
     createLogger,

--- a/projects/test-harness/src/root-app/root-app.ts
+++ b/projects/test-harness/src/root-app/root-app.ts
@@ -11,7 +11,7 @@
 import './root-app.scss';
 import './settings-panel';
 import './app-container';
-import { AppIdentifier, Channel, Context, OpenError } from '@kite9/fdc3';
+import { AppIdentifier, Channel, Context, OpenError } from '@finos/fdc3';
 import {
     AppDirectoryApplication,
     createLogger,

--- a/projects/test-harness/src/utils/fdc3.ts
+++ b/projects/test-harness/src/utils/fdc3.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { Intent } from '@kite9/fdc3';
+import type { Intent } from '@finos/fdc3';
 
 /**
  * Retrieves the standard intents from the FDC3 Intents enumeration.

--- a/projects/ui-provider/jest.config.js
+++ b/projects/ui-provider/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
     ...baseConfig,
     coverageThreshold,
     testEnvironment: 'jsdom',
-    transformIgnorePatterns: ['node_modules/(?!lit-element|lit-html|lit|@lit/|@kite9)'],
+    transformIgnorePatterns: ['node_modules/(?!lit-element|lit-html|lit|@lit/|@finos)'],
     collectCoverageFrom: ['./src/**/*.ts'],
     setupFilesAfterEnv: ['../test.ts'],
     coverageDirectory: path.join('../../build', 'coverage-results', 'ui-provider'),

--- a/projects/ui-provider/package.json
+++ b/projects/ui-provider/package.json
@@ -22,7 +22,6 @@
         "@babel/plugin-proposal-decorators": "^7.24.7",
         "@babel/preset-env": "^7.25.4",
         "@babel/preset-typescript": "^7.24.7",
-        "@kite9/fdc3": "^2.2.0-beta.25",
         "@morgan-stanley/fdc3-web": "^0.2.0",
         "@morgan-stanley/ts-mocking-bird": "^1.2.0",
         "@types/eslint": "^8.56.10",
@@ -52,10 +51,10 @@
         "typescript": "~5.6.2"
     },
     "peerDependencies": {
-        "@kite9/fdc3": "^2.2.0-beta.25",
         "@morgan-stanley/fdc3-web": "^0.1.4"
     },
     "dependencies": {
+        "@finos/fdc3": "^2.2.0-alpha.3",
         "lit": "^3.2.0",
         "lit-element": "^4.1.0"
     },

--- a/projects/ui-provider/src/app-resolver.component.spec.ts
+++ b/projects/ui-provider/src/app-resolver.component.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { AppIdentifier, AppIntent, Context, DesktopAgent, IntentMetadata, ResolveError } from '@kite9/fdc3';
+import { AppIdentifier, AppIntent, Context, DesktopAgent, IntentMetadata, ResolveError } from '@finos/fdc3';
 import { IMocked, Mock, setupFunction } from '@morgan-stanley/ts-mocking-bird';
 import { AppResolverComponent } from './app-resolver.component';
 

--- a/projects/ui-provider/src/app-resolver.component.ts
+++ b/projects/ui-provider/src/app-resolver.component.ts
@@ -8,8 +8,8 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import type { AppMetadata, Context, DesktopAgent, Icon, Intent } from '@kite9/fdc3';
-import { OpenError, ResolveError } from '@kite9/fdc3';
+import type { AppMetadata, Context, DesktopAgent, Icon, Intent } from '@finos/fdc3';
+import { OpenError, ResolveError } from '@finos/fdc3';
 import {
     FullyQualifiedAppIdentifier,
     IAppResolver,

--- a/projects/ui-provider/src/channel-selector.component.spec.ts
+++ b/projects/ui-provider/src/channel-selector.component.spec.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { Channel, DesktopAgent, EventHandler, FDC3ChannelChangedEvent, Listener } from '@kite9/fdc3';
+import { Channel, DesktopAgent, EventHandler, FDC3ChannelChangedEvent, Listener } from '@finos/fdc3';
 import { IMocked, Mock, setupFunction, setupProperty } from '@morgan-stanley/ts-mocking-bird';
 import { ChannelSelectorComponent } from './channel-selector.component';
 

--- a/projects/ui-provider/src/channel-selector.component.ts
+++ b/projects/ui-provider/src/channel-selector.component.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { type Channel, type DesktopAgent } from '@kite9/fdc3';
+import { type Channel, type DesktopAgent } from '@finos/fdc3';
 import { css, html, LitElement, TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { ClassInfo, classMap } from 'lit/directives/class-map.js';

--- a/projects/ui-provider/src/contracts.ts
+++ b/projects/ui-provider/src/contracts.ts
@@ -8,7 +8,7 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
-import { AppMetadata } from '@kite9/fdc3';
+import { AppMetadata } from '@finos/fdc3';
 
 export type IntentPopupState = { name: string; activeInstances: AppMetadata[]; inactiveApps: AppMetadata[] };
 export type ContextPopupState = Record<string, { activeInstances: AppMetadata[]; inactiveApps: AppMetadata[] }>;


### PR DESCRIPTION
This pull request
* Refactors code to use @finos/fdc3 npm package
* Moves messaging-provider to use the standard WCP message protocol messages
* Renames Private Channel Event Types to their updated names

Note that [2.2.0-beta.1 is currently broken](https://github.com/finos/FDC3/issues/1529) hence the use of 2.2.0-alpha.3.