### PR TITLE
NPM and dependency versioning rationalization

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -1,0 +1,26 @@
+# Releasing a New Version of the Library
+
+To release a new version of the library to the NPM registry, follow these steps:
+
+1. **Run the Release Command**
+    Execute the following command to start the release process:
+    ```sh
+    npm run release
+    ```
+    This command will prompt you to select the type of version bump (major, minor, patch, or pre-release). It will
+    update the versions in package.json, create a CHANGELOG.md entry and commit those changes to your local workspace.
+
+2. **Update Version and Create Pull Request**
+    After the release command completes, a new version will be created. You need to:
+    - Push the changes to your branch.
+    - Raise a Pull Request (PR) with the updated version.
+
+3. **Create a Release on GitHub**
+    Once the PR is merged, create a new release on GitHub:
+    - Go to the GitHub repository.
+    - Navigate to the "Releases" section.
+    - Click on "Draft a new release".
+    - Select the tag version of the new version created.
+    - Fill in the release details and publish the release.
+
+Creating the release on GitHub will trigger a GitHub Action that will publish the new version to the NPM registry.

--- a/nx.json
+++ b/nx.json
@@ -26,6 +26,14 @@
         }
     },
     "defaultBase": "main",
+    "release": {
+        "version": {
+            "generatorOptions": {
+                "packageRoot": "projects/{projectName}/dist/",
+                "currentVersionResolver": "git-tag"
+            }
+        }
+    },
     "plugins": [
         {
             "plugin": "@nx/eslint/plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@morgan-stanley/fdc3-web-monorepo",
-    "version": "0.2.1",
+    "version": "1.0.0",
     "license": "Apache-2.0",
     "author": "Morgan Stanley",
     "scripts": {
@@ -13,7 +13,8 @@
         "generate-docs": "nx run-many -t generate-docs",
         "prebuild-release": "npm run clean",
         "build-release": "npm run lint -- --skip-nx-cache && npm run build -- --skip-nx-cache && npm run test -- --skip-nx-cache ",
-        "postbuild-release": "npm run generate-docs"
+        "postbuild-release": "npm run generate-docs",
+        "release": "nx release"
     },
     "workspaces": [
         "projects/*"

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -24,6 +24,7 @@
     "devDependencies": {
         "@babel/preset-env": "^7.25.4",
         "@babel/preset-typescript": "^7.24.7",
+        "@finos/fdc3": "^2.2.0-alpha.3",
         "@morgan-stanley/ts-mocking-bird": "^1.2.0",
         "@types/eslint": "^8.56.10",
         "@types/eslint-scope": "^3.7.7",
@@ -54,37 +55,10 @@
         "typedoc": "^0.26.8",
         "typescript": "~5.6.2"
     },
-    "nx": {
-        "targets": {
-            "build": {
-                "executor": "@nx/js:tsc",
-                "options": {
-                    "outputPath": "{projectRoot}/dist/",
-                    "rootDir": "{projectRoot}/src",
-                    "main": "index.ts",
-                    "tsConfig": "{projectRoot}/tsconfig.json",
-                    "assets": [
-                        {
-                            "input": "{workspaceRoot}",
-                            "glob": ".npmignore",
-                            "output": "./"
-                        },
-                        {
-                            "input": "{projectRoot}",
-                            "glob": "package.json",
-                            "output": "./"
-                        },
-                        {
-                            "input": "{projectRoot}",
-                            "glob": "README.md",
-                            "output": "./"
-                        }
-                    ]
-                }
-            }
-        }
+    "peerDependencies": {
+        "@morgan-stanley/fdc3-web": ">=0.2.1 <= 1.0.0",
+        "@finos/fdc3": "^2.2.0-alpha.3"
     },
     "dependencies": {
-        "@finos/fdc3": "^2.2.0-alpha.3"
     }
 }

--- a/projects/lib/project.json
+++ b/projects/lib/project.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "name": "lib",
+    "projectType": "library",
+    "targets": {
+        "build": {
+            "executor": "@nx/js:tsc",
+            "options": {
+                "outputPath": "{projectRoot}/dist/",
+                "rootDir": "{projectRoot}/src",
+                "main": "index.ts",
+                "tsConfig": "{projectRoot}/tsconfig.json",
+                "assets": [
+                    {
+                        "input": "{workspaceRoot}",
+                        "glob": ".npmignore",
+                        "output": "./"
+                    },
+                    {
+                        "input": "{projectRoot}",
+                        "glob": "package.json",
+                        "output": "./"
+                    },
+                    {
+                        "input": "{projectRoot}",
+                        "glob": "README.md",
+                        "output": "./"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/projects/lib/src/agent/desktop-agent.spec.ts
+++ b/projects/lib/src/agent/desktop-agent.spec.ts
@@ -27,7 +27,7 @@ import {
     setupFunction,
     setupProperty,
 } from '@morgan-stanley/ts-mocking-bird';
-import { dependencies } from '../../package.json';
+import { peerDependencies } from '../../package.json';
 import { AppDirectory } from '../app-directory';
 import { AppDirectoryApplication } from '../app-directory.contracts';
 import { ChannelFactory, Channels } from '../channel';
@@ -1085,7 +1085,7 @@ describe(`${DesktopAgentImpl.name} (desktop-agent)`, () => {
 
                 await postRequestMessage(getInfoMessage, source);
 
-                const version = dependencies['@finos/fdc3'];
+                const version = peerDependencies['@finos/fdc3'];
                 const expectedVersion = (
                     version.indexOf('^') !== -1
                         ? version.slice(version.indexOf('^') + 1)

--- a/projects/messaging-provider/package.json
+++ b/projects/messaging-provider/package.json
@@ -27,7 +27,6 @@
     "devDependencies": {
         "@babel/preset-env": "^7.25.4",
         "@babel/preset-typescript": "^7.24.7",
-        "@morgan-stanley/fdc3-web": "^0.2.0",
         "@morgan-stanley/ts-mocking-bird": "^1.2.0",
         "@types/eslint": "^8.56.10",
         "@types/eslint-scope": "^3.7.7",
@@ -62,47 +61,7 @@
         "webpack-cli": "^5.1.4"
     },
     "peerDependencies": {
-        "@morgan-stanley/fdc3-web": "^0.2.1"
-    },
-    "nx": {
-        "targets": {
-            "build:relay": {
-                "executor": "@nx/webpack:webpack",
-                "options": {
-                    "webpackConfig": "{projectRoot}/webpack.config.js",
-                    "outputPath": "{projectRoot}/dist/",
-                    "rootDir": "{projectRoot}"
-                }
-            },
-            "build:library": {
-                "executor": "@nx/js:tsc",
-                "options": {
-                    "outputPath": "{projectRoot}/dist/",
-                    "rootDir": "{projectRoot}/src",
-                    "main": "{projectRoot}/dist/index.ts",
-                    "tsConfig": "{projectRoot}/tsconfig.json",
-                    "assets": [
-                        {
-                            "input": "{workspaceRoot}",
-                            "glob": ".npmignore",
-                            "output": "./"
-                        },
-                        {
-                            "input": "{projectRoot}",
-                            "glob": "package.json",
-                            "output": "./"
-                        },
-                        {
-                            "input": "{projectRoot}",
-                            "glob": "README.md",
-                            "output": "./"
-                        }
-                    ]
-                }
-            }
-        }
-    },
-    "dependencies": {
-        "@finos/fdc3": "^2.2.0-alpha.3"
+        "@morgan-stanley/fdc3-web": ">=0.2.1 <= 1.0.0",
+        "@finos/fdc3": "^2.2.0-alpha.3" 
     }
 }

--- a/projects/messaging-provider/project.json
+++ b/projects/messaging-provider/project.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "name": "messaging-provider",
+    "projectType": "library",
+    "targets": {
+        "build:relay": {
+            "executor": "@nx/webpack:webpack",
+            "options": {
+                "webpackConfig": "{projectRoot}/webpack.config.js",
+                "outputPath": "{projectRoot}/dist/",
+                "rootDir": "{projectRoot}"
+            }
+        },
+        "build:library": {
+            "executor": "@nx/js:tsc",
+            "options": {
+                "outputPath": "{projectRoot}/dist/",
+                "rootDir": "{projectRoot}/src",
+                "main": "{projectRoot}/dist/index.ts",
+                "tsConfig": "{projectRoot}/tsconfig.json",
+                "assets": [
+                    {
+                        "input": "{workspaceRoot}",
+                        "glob": ".npmignore",
+                        "output": "./"
+                    },
+                    {
+                        "input": "{projectRoot}",
+                        "glob": "package.json",
+                        "output": "./"
+                    },
+                    {
+                        "input": "{projectRoot}",
+                        "glob": "README.md",
+                        "output": "./"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/projects/test-harness/package.json
+++ b/projects/test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@morgan-stanley/fdc3-web-test-harness",
     "main": "index.html",
-    "version": "0.2.0",
+    "version": "1.0.0",
     "license": "Apache-2.0",
     "author": "Morgan Stanley",
     "scripts": {
@@ -52,10 +52,6 @@
     },
     "dependencies": {
         "@finos/fdc3": "^2.2.0-alpha.3",
-        "@morgan-stanley/fdc3-web": "^0.2.1",
-        "@morgan-stanley/fdc3-web-messaging-provider": "^0.2.1",
-        "@morgan-stanley/fdc3-web-ui-provider": "^0.2.1",
         "cors": "^2.8.5"
-    },
-    "nx": {}
+    }
 }

--- a/projects/test-harness/project.json
+++ b/projects/test-harness/project.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "name": "test-harness",
+    "projectType": "application",
+    "targets": {
+        "build": {
+            "executor": "@nx/js:tsc",
+            "options": {
+                "outputPath": "{projectRoot}/dist/",
+                "rootDir": "{projectRoot}/src",
+                "main": "index.ts",
+                "tsConfig": "{projectRoot}/tsconfig.json",
+                "assets": [
+                    {
+                        "input": "{workspaceRoot}",
+                        "glob": ".npmignore",
+                        "output": "./"
+                    },
+                    {
+                        "input": "{projectRoot}",
+                        "glob": "package.json",
+                        "output": "./"
+                    },
+                    {
+                        "input": "{projectRoot}",
+                        "glob": "README.md",
+                        "output": "./"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/projects/ui-provider/package.json
+++ b/projects/ui-provider/package.json
@@ -26,7 +26,6 @@
         "@babel/plugin-proposal-decorators": "^7.24.7",
         "@babel/preset-env": "^7.25.4",
         "@babel/preset-typescript": "^7.24.7",
-        "@morgan-stanley/fdc3-web": "^0.2.0",
         "@morgan-stanley/ts-mocking-bird": "^1.2.0",
         "@types/eslint": "^8.56.10",
         "@types/eslint-scope": "^3.7.7",
@@ -55,41 +54,11 @@
         "typescript": "~5.6.2"
     },
     "peerDependencies": {
-        "@morgan-stanley/fdc3-web": "^0.2.1"
+        "@morgan-stanley/fdc3-web": ">=0.2.1 <= 1.0.0",
+        "@finos/fdc3": "^2.2.0-alpha.3" 
     },
     "dependencies": {
-        "@finos/fdc3": "^2.2.0-alpha.3",
         "lit": "^3.2.0",
         "lit-element": "^4.1.0"
-    },
-    "nx": {
-        "targets": {
-            "build": {
-                "executor": "@nx/js:tsc",
-                "options": {
-                    "outputPath": "{projectRoot}/dist/",
-                    "rootDir": "{projectRoot}/src",
-                    "main": "src/index.ts",
-                    "tsConfig": "{projectRoot}/tsconfig.json",
-                    "assets": [
-                        {
-                            "input": "{workspaceRoot}",
-                            "glob": ".npmignore",
-                            "output": "./"
-                        },
-                        {
-                            "input": "{projectRoot}",
-                            "glob": "package.json",
-                            "output": "./"
-                        },
-                        {
-                            "input": "{projectRoot}",
-                            "glob": "README.md",
-                            "output": "./"
-                        }
-                    ]
-                }
-            }
-        }
     }
 }

--- a/projects/ui-provider/project.json
+++ b/projects/ui-provider/project.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "name": "ui-provider",
+    "projectType": "library",
+    "targets": {
+        "build": {
+            "executor": "@nx/js:tsc",
+            "options": {
+                "outputPath": "{projectRoot}/dist/",
+                "rootDir": "{projectRoot}/src",
+                "main": "index.ts",
+                "tsConfig": "{projectRoot}/tsconfig.json",
+                "assets": [
+                    {
+                        "input": "{workspaceRoot}",
+                        "glob": ".npmignore",
+                        "output": "./"
+                    },
+                    {
+                        "input": "{projectRoot}",
+                        "glob": "package.json",
+                        "output": "./"
+                    },
+                    {
+                        "input": "{projectRoot}",
+                        "glob": "README.md",
+                        "output": "./"
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request:

- Refactors versioning and dependencies
  - Removes superfluous inter-package dependencies
  - Moves `@finos/fdc3` to be a ranged peer dependency
- Refactor NX project configuration to use `project.json`
- Adds a DISTRIBUTION.md document describing the release process

I'll submit a subsequent PR that demonstrates the commit created with a `patch` release and we can release that version to NPM to ensure the consumption still works as expected.