### PR TITLE
add recursive back-off retry to app directory loading logic

### DIFF
--- a/projects/lib/src/agent/desktop-agent.factory.spec.ts
+++ b/projects/lib/src/agent/desktop-agent.factory.spec.ts
@@ -174,6 +174,7 @@ describe(`${DesktopAgentFactory.name} (desktop-agent.factory)`, () => {
 
             const agent = await instance.createRoot({
                 messagingProviderFactory: mockedFactory.mock.factory,
+                backoffRetry: { maxAttempts: 1, baseDelay: 100 },
             });
 
             expect(agent).toBeDefined();

--- a/projects/lib/src/agent/desktop-agent.factory.ts
+++ b/projects/lib/src/agent/desktop-agent.factory.ts
@@ -65,7 +65,11 @@ export class DesktopAgentFactory {
 
         log('Messaging Provider constructed', 'debug');
 
-        const directory = new AppDirectory(appResolverPromise, factoryParams.appDirectoryUrls);
+        const directory = new AppDirectory(
+            appResolverPromise,
+            factoryParams.appDirectoryUrls,
+            factoryParams.backoffRetry,
+        );
         const rootMessagePublisher =
             this.rootMessagePublisherFactory != null
                 ? this.rootMessagePublisherFactory(messagingProvider, directory, window)
@@ -90,7 +94,7 @@ export class DesktopAgentFactory {
             openStrategies: factoryParams.openStrategies,
         });
 
-        log('Agent constructed', 'debug', agent);
+        log('Root Agent constructed', 'debug');
 
         agentResolve(agent);
 

--- a/projects/lib/src/constants.ts
+++ b/projects/lib/src/constants.ts
@@ -8,6 +8,8 @@
  * or implied. See the License for the specific language governing permissions
  * and limitations under the License. */
 
+import { BackoffRetryParams } from './contracts.js';
+
 export const FDC3_VERSION = '2.2.0';
 export const FDC3_PROVIDER = 'Morgan Stanley';
 
@@ -40,3 +42,8 @@ export const HEARTBEAT = {
      */
     TIMEOUT_MS: 500,
 } as const;
+
+export const defaultBackoffRetry: Required<BackoffRetryParams> = {
+    maxAttempts: 3,
+    baseDelay: 250,
+};

--- a/projects/lib/src/contracts.ts
+++ b/projects/lib/src/contracts.ts
@@ -225,12 +225,27 @@ export interface IAppResolver {
  */
 export interface IUIProvider extends IAppResolver {}
 
+export type BackoffRetryParams = {
+    /**
+     * The maximum number of attempts to retry the connection. This includes the first attempt.
+     */
+    maxAttempts?: number;
+    /**
+     * The initial delay in milliseconds before the first retry attempt. This will increase exponentially with each attempt
+     */
+    baseDelay?: number;
+};
+
 export type RootDesktopAgentFactoryParams = {
     messagingProviderFactory?: MessagingProviderFactory<IRootMessagingProvider>;
     uiProvider?: UIProviderFactory;
     appDirectoryUrls?: string[];
     openStrategies?: IOpenApplicationStrategy[];
     identityUrl?: string;
+    /**
+     * retry parameters for the root agent to retry loading the app directory urls
+     */
+    backoffRetry?: BackoffRetryParams;
 };
 
 export type ProxyDesktopAgentFactoryParams = {


### PR DESCRIPTION
We need this in the test-harness as often the ui starts before the mock server does but it's obviously a good idea to have it anyway.