### PR TITLE
Automatically open a new instance of an app or select an existing instance if app resolver only finds 1 candidate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - run: npm ci && npm run build-release
+    - run: npm ci && npm run build:release
 
     - name: Codecov
       uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -32,7 +32,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Install node modules and verify build
-        run: npm ci && npm run build-release
+        run: npm ci && npm run build:release
 
       - name: Publish FDC3 Library
         run: cd dist/fdc3-web && npm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ npm run test
 npm run lint 
 
 # Run a full build (Compile, Tests, Lint)
-npm run build-release
+npm run build:release
 
 # test a single project
 npx nx test fdc3-web 

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
         "type-check-specs": "nx run-many -t type-check-specs",
         "start": "nx serve test-harness",
         "generate-docs": "nx run-many -t generate-docs",
-        "prebuild-release": "npm run clean",
-        "build-release": "npm run lint -- --skip-nx-cache && npm run build -- --skip-nx-cache && npm run test -- --skip-nx-cache && npm run type-check-specs -- --skip-nx-cache",
-        "postbuild-release": "npm run generate-docs",
+        "prebuild:release": "npm run clean",
+        "build:release": "npm run lint -- --skip-nx-cache && npm run build -- --skip-nx-cache && npm run test -- --skip-nx-cache && npm run type-check-specs -- --skip-nx-cache",
+        "postbuild:release": "npm run generate-docs",
         "release": "nx release"
     },
     "workspaces": [

--- a/projects/lib/README.md
+++ b/projects/lib/README.md
@@ -52,7 +52,7 @@ To contribute to the FDC3 library and its plugins, follow these steps:
 1. Fork the repository on BitBucket.
 2. Clone the forked repository to your local machine.
 3. Install the required dependencies using `npm install`.
-4. Make your changes and ensure that the full build is executing successfully with `npm run build-release`.
+4. Make your changes and ensure that the full build is executing successfully with `npm run build:release`.
 5. Submit a pull request with your changes, providing a clear description of the modifications made.
 
 We welcome contributions from the community and appreciate your efforts in improving the FDC3 library.


### PR DESCRIPTION
This fixes a bug in the default app resolver and will improve conformance tests. Currently if there is only 1 instance available it is still shown in the app resolver UI.