### PR TITLE
Do not append /v2/apps to app directory URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const agent = await getAgent({
   failover: () =>
     new DesktopAgentFactory().createRoot({
       uiProvider: agent => Promise.resolve(new AppResolverComponent(agent, document)),
-      appDirectoryUrls: ['http://localhost:4299'],
+      appDirectoryUrls: ['http://localhost:4299/v2/apps'],
       openStrategies: [{
         canOpen: (params: OpenApplicationStrategyParams) => { /* define whether an app should open */ },
         open: (params: OpenApplicationStrategyParams) => { /* define how an app should open */ }
@@ -101,12 +101,12 @@ To enable app discovery and intent resolution, provide App Directory URLs when i
 
 ```js
 const agent = await getAgent({
-  appDirectoryUrls: ['http://localhost:4299'],
+  appDirectoryUrls: ['http://localhost:4299/v2/apps'],
 });
 
 // Fetch available applications
 import { getAppDirectoryApplications } from '@morgan-stanley/fdc3-web';
-const apps = await getAppDirectoryApplications('http://localhost:4299');
+const apps = await getAppDirectoryApplications('http://localhost:4299/v2/apps');
 ```
 
 For more advanced usage, see the [test-harness](./projects/test-harness/README.md) example app.

--- a/projects/lib/src/agent/desktop-agent.factory.ts
+++ b/projects/lib/src/agent/desktop-agent.factory.ts
@@ -76,7 +76,7 @@ export class DesktopAgentFactory {
                 : new RootMessagePublisher(messagingProvider, directory, window);
 
         // retrieve the root agent details from the app directory
-        const appIdentifier = await rootMessagePublisher.initialize();
+        const appIdentifier = await rootMessagePublisher.initialize(factoryParams.identityUrl);
 
         if (appIdentifier == null) {
             log('AppIdentifier could not be resolved', LogLevel.ERROR);

--- a/projects/lib/src/helpers/app-directory-applications.helper.spec.ts
+++ b/projects/lib/src/helpers/app-directory-applications.helper.spec.ts
@@ -56,7 +56,7 @@ describe('app-directory-applications.helper', () => {
             const result = await getAppDirectoryApplications(mockAppDirectoryUrl);
 
             // Verify fetch was called with the correct URL
-            expect(global.fetch).toHaveBeenCalledWith(`${mockAppDirectoryUrl}/v2/apps`);
+            expect(global.fetch).toHaveBeenCalledWith(`${mockAppDirectoryUrl}`);
 
             // Verify the returned applications match the mock data
             expect(result).toEqual(mockApplications);

--- a/projects/lib/src/helpers/app-directory-applications.helper.ts
+++ b/projects/lib/src/helpers/app-directory-applications.helper.ts
@@ -29,7 +29,7 @@ export async function getAppDirectoryApplicationsImpl(
     attempt = 1,
 ): Promise<AppDirectoryApplication[]> {
     try {
-        const response = await fetch(`${url}/v2/apps`).then(response => response.json()); // TODO: retry if initial fetch fails
+        const response = await fetch(`${url}`).then(response => response.json()); // TODO: retry if initial fetch fails
         if (response.message != 'OK' || response.applications == null) {
             //request has failed for this app directory url
             return [];

--- a/projects/test-harness/src/root-app/root-app.ts
+++ b/projects/test-harness/src/root-app/root-app.ts
@@ -46,7 +46,7 @@ import {
     SelectAppContextType,
 } from '../contracts.js';
 
-const appDirectoryUrls = ['http://localhost:4299'];
+const appDirectoryUrls = ['http://localhost:4299/v2/apps'];
 
 const retryParams: BackoffRetryParams = {
     maxAttempts: 5,


### PR DESCRIPTION
The FDC3 spec says that app directory URL's should be found in these locations

https://fdc3.finos.org/docs/app-directory/spec#endpoints

However, this poses a number of problems in regard to having to configure hosting providers for default documents or run an external rest end point.  I have raised an issue here

https://github.com/finos/fdc3/issues/1622

Now, in this library, I think the current behaviour of blindly adding /v2/apps is already broken is some regard as the developer may have already done that in in the URL.  Perhaps better is to not touch the URL at all and leave the responsibility in the developers hands to provide the correct URL. That way if the issue above is resolved this would still work http://mydomain/path/file.json 

However the problem with this PR is that we are now breaking people who expect the v2/apps to be appended.  There is no simple fix here afaics. 