### PR TITLE
support root app directory entry

### DIFF
--- a/projects/fdc3-web/src/agent/desktop-agent.factory.ts
+++ b/projects/fdc3-web/src/agent/desktop-agent.factory.ts
@@ -69,6 +69,7 @@ export class DesktopAgentFactory {
             appResolverPromise,
             factoryParams.appDirectoryEntries,
             factoryParams.backoffRetry,
+            factoryParams.appDirectoryEntry,
         );
         const rootMessagePublisher =
             this.rootMessagePublisherFactory != null

--- a/projects/fdc3-web/src/app-directory/directory.spec.ts
+++ b/projects/fdc3-web/src/app-directory/directory.spec.ts
@@ -136,8 +136,15 @@ describe(`${AppDirectory.name} (directory)`, () => {
         appDirectoryUrls?: (string | LocalAppDirectory)[],
         backoffRetry?: BackoffRetryParams,
         appId = 'mock-root-app-id',
+        rootAppDirectoryEntry?: Omit<AppDirectoryApplication, 'appId'>,
     ): AppDirectory {
-        return new AppDirectory(appId, Promise.resolve(mockResolver.mock), appDirectoryUrls, backoffRetry);
+        return new AppDirectory(
+            appId,
+            Promise.resolve(mockResolver.mock),
+            appDirectoryUrls,
+            backoffRetry,
+            rootAppDirectoryEntry,
+        );
     }
 
     it(`should create`, () => {
@@ -153,6 +160,48 @@ describe(`${AppDirectory.name} (directory)`, () => {
 
         expect(instance.rootAppIdentifier.appId).toEqual('fully-qualified-app-id@some-domain');
         expect(typeof instance.rootAppIdentifier.instanceId).toBe('string');
+    });
+
+    it(`should not include root app in applications when no rootAppDirectoryEntry is provided`, () => {
+        const instance = createInstance();
+
+        expect(instance.applications).toEqual([]);
+    });
+
+    it(`should include root app in applications when rootAppDirectoryEntry is provided`, () => {
+        const rootEntry: Omit<AppDirectoryApplication, 'appId'> = {
+            title: 'Root App',
+            type: 'web' as AppDirectoryApplicationType,
+            details: { url: 'https://root-app-url' },
+            interop: {
+                intents: {
+                    listensFor: {
+                        StartChat: { contexts: ['fdc3.contact'] },
+                    },
+                },
+            },
+        };
+        const instance = createInstance(undefined, undefined, 'mock-root-app-id', rootEntry);
+
+        expect(instance.applications).toHaveLength(1);
+        expect(instance.applications[0].appId).toEqual('mock-root-app-id@localhost');
+        expect(instance.applications[0].title).toEqual('Root App');
+        expect(instance.applications[0].interop?.intents?.listensFor?.StartChat).toEqual({
+            contexts: ['fdc3.contact'],
+        });
+    });
+
+    it(`should merge rootAppDirectoryEntry appId with derived fully qualified appId`, () => {
+        const rootEntry: Omit<AppDirectoryApplication, 'appId'> = {
+            title: 'Root App',
+            type: 'web' as AppDirectoryApplicationType,
+            details: { url: 'https://root-app-url' },
+        };
+        const instance = createInstance(undefined, undefined, 'fully-qualified-app-id@some-domain', rootEntry);
+
+        expect(instance.applications).toHaveLength(1);
+        expect(instance.applications[0].appId).toEqual('fully-qualified-app-id@some-domain');
+        expect(instance.applications[0].title).toEqual('Root App');
     });
 
     describe(`resolveAppForIntent`, () => {

--- a/projects/fdc3-web/src/app-directory/directory.ts
+++ b/projects/fdc3-web/src/app-directory/directory.ts
@@ -62,8 +62,9 @@ export class AppDirectory {
         private readonly appResolverPromise: Promise<IAppResolver>,
         appDirectoryEntries?: (string | LocalAppDirectory)[],
         backoffRetry?: BackoffRetryParams,
+        rootAppDirectoryEntry?: Omit<AppDirectoryApplication, 'appId'>,
     ) {
-        this._rootAppIdentifier = this.registerRootApp(rootAppId);
+        this._rootAppIdentifier = this.registerRootApp(rootAppId, rootAppDirectoryEntry);
 
         //assumes app directory is not modified while root desktop agent is active
         this.appDirectoryEntries = appDirectoryEntries ?? [];
@@ -82,14 +83,20 @@ export class AppDirectory {
         return this._rootAppIdentifier;
     }
 
-    private registerRootApp(rootAppId: string): FullyQualifiedAppIdentifier {
+    private registerRootApp(
+        rootAppId: string,
+        rootAppDirectoryEntry?: Omit<AppDirectoryApplication, 'appId'>,
+    ): FullyQualifiedAppIdentifier {
         const appId: FullyQualifiedAppId = isFullyQualifiedAppId(rootAppId)
             ? rootAppId
             : `${rootAppId}@${window.location.hostname}`;
 
         const rootAppIdentifier = { appId, instanceId: generateUUID() };
 
-        this.directory[appId] = { instances: [rootAppIdentifier.instanceId] };
+        const application: AppDirectoryApplication | undefined =
+            rootAppDirectoryEntry != null ? { ...rootAppDirectoryEntry, appId } : undefined;
+
+        this.directory[appId] = { application, instances: [rootAppIdentifier.instanceId] };
         this.instanceLookup[rootAppIdentifier.instanceId] = {};
 
         return rootAppIdentifier;

--- a/projects/fdc3-web/src/contracts.ts
+++ b/projects/fdc3-web/src/contracts.ts
@@ -302,6 +302,11 @@ export type RootDesktopAgentFactoryParams = {
      */
     backoffRetry?: BackoffRetryParams;
     logLevels?: GetAgentLogLevels;
+    /**
+     * Optional app directory entry for the root application. When provided this will be used when the root app is added to the application directory, allowing consumers to specify intents the root agent listens for via the interop property.
+     * The appId field is omitted as it is derived from rootAppId.
+     */
+    appDirectoryEntry?: Omit<AppDirectoryApplication, 'appId'>;
 };
 
 export type ProxyDesktopAgentFactoryParams = {


### PR DESCRIPTION
This allows us to set the app directory entry for the root app to specify what intents it listens for for example