### PR TITLE
Handle qualified and unqualified app IDs in resolvers

### DIFF
--- a/projects/fdc3-web/src/app-directory/app-resolver.default.spec.ts
+++ b/projects/fdc3-web/src/app-directory/app-resolver.default.spec.ts
@@ -303,4 +303,70 @@ describe(`${DefaultResolver.name} (app-resolver.default)`, () => {
             }
         });
     });
+
+    describe('qualified and unqualified app ids', () => {
+        const fullyQualifiedAppId = 'my-app@jubako.ms.com';
+        const unqualifiedAppId = 'my-app';
+
+        it('should resolve the correct app when given a fully qualified app id', async () => {
+            const instance = createInstance();
+
+            const appIntent: AppIntent = {
+                apps: [{ appId: fullyQualifiedAppId }, { appId: 'other-app@jubako.ms.com' }],
+                intent: { name: 'StartEmail', displayName: 'StartEmail' },
+            };
+
+            const payload: ResolveForIntentPayload = {
+                context: { type: 'contact' },
+                appIdentifier: { appId: fullyQualifiedAppId },
+                intent: 'StartEmail',
+                appManifests: {},
+                appIntent,
+            };
+
+            await expect(instance.resolveAppForIntent(payload)).resolves.toEqual({ appId: fullyQualifiedAppId });
+        });
+
+        it('should resolve the correct app when given an unqualified app id', async () => {
+            const instance = createInstance();
+
+            const appIntent: AppIntent = {
+                apps: [{ appId: fullyQualifiedAppId }, { appId: 'other-app@jubako.ms.com' }],
+                intent: { name: 'StartEmail', displayName: 'StartEmail' },
+            };
+
+            const payload: ResolveForIntentPayload = {
+                context: { type: 'contact' },
+                appIdentifier: { appId: unqualifiedAppId },
+                intent: 'StartEmail',
+                appManifests: {},
+                appIntent,
+            };
+
+            await expect(instance.resolveAppForIntent(payload)).resolves.toEqual({ appId: fullyQualifiedAppId });
+        });
+
+        it('should resolve the correct app for context when given an unqualified app id', async () => {
+            const instance = createInstance();
+
+            const appIntents: AppIntent[] = [
+                {
+                    apps: [{ appId: fullyQualifiedAppId }, { appId: 'other-app@jubako.ms.com' }],
+                    intent: { name: 'StartEmail', displayName: 'StartEmail' },
+                },
+            ];
+
+            const payload: ResolveForContextPayload = {
+                context: { type: 'contact' },
+                appIdentifier: { appId: unqualifiedAppId },
+                appManifests: {},
+                appIntents,
+            };
+
+            await expect(instance.resolveAppForContext(payload)).resolves.toEqual({
+                intent: 'StartEmail',
+                app: { appId: fullyQualifiedAppId, instanceId: undefined },
+            });
+        });
+    });
 });

--- a/projects/fdc3-web/src/app-directory/app-resolver.default.ts
+++ b/projects/fdc3-web/src/app-directory/app-resolver.default.ts
@@ -16,7 +16,7 @@ import {
     ResolveForContextResponse,
     ResolveForIntentPayload,
 } from '../contracts.js';
-import { filterActiveApps, filterInactiveApps } from '../helpers/index.js';
+import { appIdsMatch, filterActiveApps, filterInactiveApps } from '../helpers/index.js';
 
 /**
  * If no IUIProvider is present then this class is used to resolve apps.
@@ -55,9 +55,10 @@ export class DefaultResolver implements IAppResolver {
             appIntents
                 //filters out intents which cannot be handled by given AppIdentifier if one is provided
                 .map(appIntent => {
+                    const requestedAppId = payload.appIdentifier?.appId;
                     const apps =
-                        payload.appIdentifier != null
-                            ? appIntent.apps.filter(app => app.appId === payload.appIdentifier?.appId)
+                        requestedAppId != null
+                            ? appIntent.apps.filter(app => appIdsMatch(app.appId, requestedAppId))
                             : appIntent.apps;
 
                     return { ...appIntent, apps };
@@ -95,7 +96,9 @@ export class DefaultResolver implements IAppResolver {
         identifier: AppIdentifier | undefined,
         apps: AppIdentifier[],
     ): Promise<AppIdentifier> {
-        const matchingApps = apps.filter(knownApp => identifier?.appId == null || knownApp.appId === identifier.appId);
+        const matchingApps = apps.filter(
+            knownApp => identifier?.appId == null || appIdsMatch(knownApp.appId, identifier.appId),
+        );
 
         if (matchingApps.length === 1 && matchingApps[0] != null) {
             return matchingApps[0];

--- a/projects/fdc3-web/src/app-directory/directory.spec.ts
+++ b/projects/fdc3-web/src/app-directory/directory.spec.ts
@@ -357,7 +357,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
             expect(mockResolver.withFunction('resolveAppForIntent')).wasCalledOnce();
         });
 
-        it(`should resolve fully-qualified appId from different hostname by matching unqualified part`, async () => {
+        it(`should reject Promise with TargetAppUnavailable for fully-qualified appId from a different hostname`, async () => {
             const instance = createInstance([mockedAppDirectoryUrl]);
 
             await registerApp(instance, mockedApplicationOne, 'StartChat', []);
@@ -367,9 +367,9 @@ describe(`${AppDirectory.name} (directory)`, () => {
                 instanceId: 'instanceOne',
             };
 
-            const result = await instance.resolveAppForIntent('StartChat', { type: 'contact' }, identifier);
+            const result = instance.resolveAppForIntent('StartChat', { type: 'contact' }, identifier);
 
-            expect(result).toStrictEqual({ appId: mockedAppIdOne, instanceId: 'instanceOne' });
+            await expect(result).rejects.toEqual(ResolveError.TargetAppUnavailable);
             expect(mockResolver.withFunction('resolveAppForIntent')).wasNotCalled();
         });
 
@@ -714,14 +714,14 @@ describe(`${AppDirectory.name} (directory)`, () => {
             expect(result).toEqual([{ appId: mockedAppIdOne, instanceId: 'instanceOne' }]);
         });
 
-        it(`should resolve fully-qualified appId from a different hostname to matching unqualified part`, async () => {
+        it(`should return undefined for fully-qualified appId from a different hostname`, async () => {
             const instance = createInstance([mockedAppDirectoryUrl]);
 
             await registerApp(instance, mockedApplicationOne, 'StartChat', []);
 
             const result = await instance.getAppInstances('app-id-one@different-hostname');
 
-            expect(result).toEqual([{ appId: mockedAppIdOne, instanceId: 'instanceOne' }]);
+            expect(result).toBeUndefined();
         });
 
         it('should return multiple app instances from different hostnames that match the unqualified appId if multiple fully qualified appIds exist in the directory', async () => {
@@ -794,7 +794,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
             });
         });
 
-        it(`should resolve fully-qualified appId from different hostname by matching unqualified part`, async () => {
+        it(`should return undefined for fully-qualified appId from a different hostname`, async () => {
             const instance = createInstance([mockedAppDirectoryUrl]);
 
             await registerApp(instance, mockedApplicationOne, 'StartChat', []);
@@ -804,16 +804,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
                 instanceId: 'instanceOne',
             });
 
-            expect(result).toEqual({
-                appId: 'app-id-one@different-hostname',
-                instanceId: 'instanceOne',
-                description: undefined,
-                icons: undefined,
-                screenshots: undefined,
-                title: 'app-title-one',
-                tooltip: undefined,
-                version: undefined,
-            });
+            expect(result).toBeUndefined();
         });
     });
 

--- a/projects/fdc3-web/src/app-directory/directory.ts
+++ b/projects/fdc3-web/src/app-directory/directory.ts
@@ -29,6 +29,7 @@ import {
     ResolveForContextResponse,
 } from '../contracts.js';
 import {
+    appIdsMatch,
     createLogger,
     generateUUID,
     getAppDirectoryApplications,
@@ -41,7 +42,6 @@ import {
     mapLocalAppDirectory,
     mapUrlToFullyQualifiedAppId,
     resolveAppIdentifier,
-    toUnqualifiedAppId,
     urlContainsAllElements,
 } from '../helpers/index.js';
 
@@ -339,19 +339,16 @@ export class AppDirectory {
     }
 
     /**
-     * Returns all FullyQualifiedAppIds that match the given appId using FDC3 cross-matching rules.
+     * Returns all FullyQualifiedAppIds in the directory that match the given appId.
+     * Matching tolerates a mix of fully qualified (appId@hostname) and unqualified (appId) forms via
+     * appIdsMatch: an unqualified id matches any host, but two fully qualified ids must match exactly so the
+     * same unqualified name hosted on different hosts is not treated as a match.
      * Used by findInstances where multiple matches should all be returned.
      */
     private getAllMatchingFullyQualifiedAppIds(appId: string): FullyQualifiedAppId[] {
-        if (isFullyQualifiedAppId(appId) && this.directory[appId] != null) {
-            return [appId];
-        }
-
-        const unqualifiedAppId = isFullyQualifiedAppId(appId) ? toUnqualifiedAppId(appId) : appId;
-
         return Object.keys(this.directory)
             .filter(isFullyQualifiedAppId)
-            .filter(knownId => toUnqualifiedAppId(knownId) === unqualifiedAppId);
+            .filter(knownId => appIdsMatch(knownId, appId));
     }
 
     /**

--- a/projects/fdc3-web/src/contracts.ts
+++ b/projects/fdc3-web/src/contracts.ts
@@ -221,6 +221,11 @@ export type AppHostManifestLookup = Partial<Record<string, IMSHostManifest>>;
 
 export type ResolveForIntentPayload = {
     context: Context;
+    /**
+     * Optional app identifier used to filter the resolved apps. The appId may be either fully
+     * qualified (appId@hostname) or unqualified (appId only); the resolver normalizes both forms
+     * before matching against the app directory entries.
+     */
     appIdentifier?: UnqualifiedAppIdentifier;
     intent: Intent;
     // used to indicate if an app is a singleton app
@@ -233,6 +238,11 @@ export type ResolveForIntentPayload = {
 
 export type ResolveForContextPayload = {
     context: Context;
+    /**
+     * Optional app identifier used to filter the resolved apps. The appId may be either fully
+     * qualified (appId@hostname) or unqualified (appId only); the resolver normalizes both forms
+     * before matching against the app directory entries.
+     */
     appIdentifier?: UnqualifiedAppIdentifier;
     // used to indicate if an app is a singleton app
     appManifests: AppHostManifestLookup;

--- a/projects/fdc3-web/src/helpers/app-identity.helper.spec.ts
+++ b/projects/fdc3-web/src/helpers/app-identity.helper.spec.ts
@@ -10,7 +10,7 @@
 
 import type { AppIdentifier } from '@finos/fdc3';
 import { describe, expect, it } from 'vitest';
-import { appInstanceEquals, resolveAppIdentifier } from './app-identity.helper.js';
+import { appIdsMatch, appInstanceEquals, resolveAppIdentifier, toUnqualifiedAppId } from './app-identity.helper.js';
 
 describe(`app-identity.helper`, () => {
     describe(`${appInstanceEquals.name} (app-identity.helper)`, () => {
@@ -77,6 +77,46 @@ describe(`app-identity.helper`, () => {
             const appIdentifier = resolveAppIdentifier();
 
             expect(appIdentifier).toBeUndefined();
+        });
+    });
+
+    describe(`${toUnqualifiedAppId.name} (app-identity.helper)`, () => {
+        it('should strip the host from a fully qualified app id', () => {
+            expect(toUnqualifiedAppId('my-app@jubako.ms.com')).toBe('my-app');
+        });
+
+        it('should return an unqualified app id unchanged', () => {
+            expect(toUnqualifiedAppId('my-app')).toBe('my-app');
+        });
+    });
+
+    describe(`${appIdsMatch.name} (app-identity.helper)`, () => {
+        it('should match two identical fully qualified app ids', () => {
+            expect(appIdsMatch('my-app@jubako.ms.com', 'my-app@jubako.ms.com')).toBe(true);
+        });
+
+        it('should match two identical unqualified app ids', () => {
+            expect(appIdsMatch('my-app', 'my-app')).toBe(true);
+        });
+
+        it('should match an unqualified app id against a fully qualified app id', () => {
+            expect(appIdsMatch('my-app@jubako.ms.com', 'my-app')).toBe(true);
+        });
+
+        it('should match a fully qualified app id against an unqualified app id', () => {
+            expect(appIdsMatch('my-app', 'my-app@jubako.ms.com')).toBe(true);
+        });
+
+        it('should not match different unqualified app ids', () => {
+            expect(appIdsMatch('my-app', 'other-app')).toBe(false);
+        });
+
+        it('should not match the same unqualified name on different hosts', () => {
+            expect(appIdsMatch('my-app@host-one.ms.com', 'my-app@host-two.ms.com')).toBe(false);
+        });
+
+        it('should not match an unqualified app id against a different fully qualified app id', () => {
+            expect(appIdsMatch('other-app@jubako.ms.com', 'my-app')).toBe(false);
         });
     });
 });

--- a/projects/fdc3-web/src/helpers/app-identity.helper.ts
+++ b/projects/fdc3-web/src/helpers/app-identity.helper.ts
@@ -54,3 +54,25 @@ export function resolveAppIdentifier(
 export function toUnqualifiedAppId(appId: string): string {
     return isFullyQualifiedAppId(appId) ? appId.split('@')[0] : appId;
 }
+
+/**
+ * Determines whether two app ids refer to the same application, tolerating a mix of fully
+ * qualified (appId@hostname) and unqualified (appId) forms.
+ *
+ * - If the two ids are equal they match.
+ * - If both ids are fully qualified they must match exactly, so the same unqualified name hosted
+ *   on different hosts is not treated as a match.
+ * - Otherwise (at least one id is unqualified) the unqualified portions are compared, allowing an
+ *   unqualified id to match a fully qualified one and vice versa.
+ */
+export function appIdsMatch(appIdOne: string, appIdTwo: string): boolean {
+    if (appIdOne === appIdTwo) {
+        return true;
+    }
+
+    if (isFullyQualifiedAppId(appIdOne) && isFullyQualifiedAppId(appIdTwo)) {
+        return false;
+    }
+
+    return toUnqualifiedAppId(appIdOne) === toUnqualifiedAppId(appIdTwo);
+}

--- a/projects/ui-provider/src/app-resolver.component.spec.ts
+++ b/projects/ui-provider/src/app-resolver.component.spec.ts
@@ -462,6 +462,61 @@ describe(`${AppResolverComponent.name} (app-resolver.component)`, () => {
         });
     });
 
+    describe('qualified and unqualified app ids', () => {
+        const fullyQualifiedAppId = 'my-app@jubako.ms.com';
+        const unqualifiedAppId = 'my-app';
+
+        it('should resolve the correct app when given a fully qualified app id', async () => {
+            const instance = createInstance();
+
+            const apps: AppIdentifier[] = [{ appId: fullyQualifiedAppId }, { appId: 'other-app@jubako.ms.com' }];
+            const payload = createIntentPayload(true, apps, { appId: fullyQualifiedAppId });
+
+            await expect(instance.resolveAppForIntent(payload)).resolves.toEqual({ appId: fullyQualifiedAppId });
+        });
+
+        it('should resolve the correct app when given an unqualified app id', async () => {
+            const instance = createInstance();
+
+            const apps: AppIdentifier[] = [{ appId: fullyQualifiedAppId }, { appId: 'other-app@jubako.ms.com' }];
+            const payload = createIntentPayload(true, apps, { appId: unqualifiedAppId });
+
+            await expect(instance.resolveAppForIntent(payload)).resolves.toEqual({ appId: fullyQualifiedAppId });
+        });
+
+        it('should resolve the correct app for context when given an unqualified app id', async () => {
+            const instance = createInstance();
+
+            const appIntents: AppIntent[] = [
+                {
+                    apps: [{ appId: fullyQualifiedAppId }, { appId: 'other-app@jubako.ms.com' }],
+                    intent: { name: 'StartEmail', displayName: 'StartEmail' },
+                },
+            ];
+            const payload: ResolveForContextPayload = {
+                context: { type: 'contact' },
+                appIdentifier: { appId: unqualifiedAppId },
+                appManifests: {},
+                appIntents,
+            };
+
+            await expect(instance.resolveAppForContext(payload)).resolves.toEqual({
+                intent: 'StartEmail',
+                app: { appId: fullyQualifiedAppId },
+            });
+        });
+    });
+
+    describe('constructor', () => {
+        it('should accept a desktop agent that is not wrapped in a promise', async () => {
+            const instance = new AppResolverComponent(mockAgent.mock, mockDocument);
+
+            const payload = createIntentPayload(true, [create(1)]);
+
+            await expect(instance.resolveAppForIntent(payload)).resolves.toEqual({ appId: '1' });
+        });
+    });
+
     describe('selectApp', () => {
         it('should pass given app and intent to selectedAppCallback', async () => {
             const instance = createInstance();

--- a/projects/ui-provider/src/app-resolver.component.ts
+++ b/projects/ui-provider/src/app-resolver.component.ts
@@ -11,6 +11,7 @@
 import type { AppIdentifier, AppMetadata, Context, DesktopAgent, Icon, Intent } from '@finos/fdc3';
 import { ResolveError } from '@finos/fdc3';
 import {
+    appIdsMatch,
     filterActiveApps,
     filterInactiveApps,
     IAppResolver,
@@ -169,7 +170,7 @@ export class AppResolverComponent extends LitElement implements IAppResolver {
     private selectedAppCallback: ((app: AppMetadata, intent: Intent) => void) | undefined;
 
     constructor(
-        private readonly desktopAgentPromise: Promise<DesktopAgent>,
+        private readonly desktopAgent: DesktopAgent | Promise<DesktopAgent>,
         private readonly document: Document,
         public readonly automationIdAttribute: string = DEFAULT_AUTOMATION_ID_ATTRIBUTE,
     ) {
@@ -179,12 +180,13 @@ export class AppResolverComponent extends LitElement implements IAppResolver {
     }
 
     public async resolveAppForIntent(payload: ResolveForIntentPayload): Promise<AppIdentifier> {
-        const agent = await this.desktopAgentPromise;
+        const agent = await this.desktopAgent;
 
         const appIntent = payload.appIntent ?? (await agent.findIntent(payload.intent, payload.context));
         let apps: AppMetadata[] = appIntent.apps;
-        if (payload.appIdentifier != null) {
-            apps = apps.filter(app => app.appId === payload.appIdentifier?.appId);
+        const requestedAppId = payload.appIdentifier?.appId;
+        if (requestedAppId != null) {
+            apps = apps.filter(app => appIdsMatch(app.appId, requestedAppId));
         }
 
         const activeInstances = apps.filter(app => app.instanceId != null);
@@ -208,7 +210,7 @@ export class AppResolverComponent extends LitElement implements IAppResolver {
     }
 
     public async resolveAppForContext(payload: ResolveForContextPayload): Promise<ResolveForContextResponse> {
-        const agent = await this.desktopAgentPromise;
+        const agent = await this.desktopAgent;
 
         const appIntents = payload.appIntents ?? (await agent.findIntentsByContext(payload.context));
 
@@ -220,9 +222,10 @@ export class AppResolverComponent extends LitElement implements IAppResolver {
             appIntents
                 //filters out intents which cannot be handled by given AppIdentifier if one is provided
                 .map(appIntent => {
+                    const requestedAppId = payload.appIdentifier?.appId;
                     const apps =
-                        payload.appIdentifier != null
-                            ? appIntent.apps.filter(app => app.appId === payload.appIdentifier?.appId)
+                        requestedAppId != null
+                            ? appIntent.apps.filter(app => appIdsMatch(app.appId, requestedAppId))
                             : appIntent.apps;
 
                     return { ...appIntent, apps };


### PR DESCRIPTION
The UI/app resolvers matched the caller-supplied appIdentifier.appId against directory apps with strict equality, but directory entries are keyed by fully qualified IDs (name@host). Passing an unqualified ID silently failed to match.

- Add appIdsMatch helper that normalizes both forms before comparing
- Use it in AppResolverComponent and DefaultResolver intent/context paths
- Widen AppResolverComponent constructor to accept an agent or a promise
- Cover both forms with unit tests