### PR TITLE
Implement missing FDC3 Web Connection Protocol steps

### DIFF
--- a/projects/fdc3-web/src/app-directory/directory.ts
+++ b/projects/fdc3-web/src/app-directory/directory.ts
@@ -222,6 +222,12 @@ export class AppDirectory {
      */
     public async registerNewInstance(
         identityUrl: string,
+        /**
+         * When an app reconnects (e.g. after a navigation or refresh event) the Desktop Agent may
+         * reissue its previous instanceId. When supplied, this id is used instead of generating a new
+         * one, ensuring a consistent instanceId across the reconnection.
+         */
+        requestedInstanceId?: string,
     ): Promise<{ identifier: FullyQualifiedAppIdentifier; application: AppDirectoryApplication }> {
         //ensures app directory has finished loading before intentListeners can be added dynamically
         await this.loadDirectoryPromise;
@@ -229,7 +235,10 @@ export class AppDirectory {
         this.log('Registering new instance', LogLevel.DEBUG, identityUrl);
         const application = await this.resolveAppIdentity(identityUrl);
 
-        const identifier = application != null ? { appId: application.appId, instanceId: generateUUID() } : undefined;
+        const identifier =
+            application != null
+                ? { appId: application.appId, instanceId: requestedInstanceId ?? generateUUID() }
+                : undefined;
         const appId = identifier?.appId;
 
         if (identifier == null || !isFullyQualifiedAppId(appId) || application == null) {
@@ -239,12 +248,28 @@ export class AppDirectory {
 
         const appEntry = this.directory[appId] ?? (this.directory[appId] = { instances: [] });
 
-        appEntry.instances.push(identifier.instanceId);
+        // Guard against registering the same instanceId twice when reconnecting with a reissued id.
+        if (!appEntry.instances.includes(identifier.instanceId)) {
+            appEntry.instances.push(identifier.instanceId);
+        }
 
         //copy across intents app listens for
         this.populateInstanceLookup(identifier.instanceId, appEntry.application);
 
         return { identifier, application };
+    }
+
+    /**
+     * Resolves the fully qualified appId that an identityUrl maps to, or undefined if the app is not
+     * known to the Desktop Agent. Unlike registerNewInstance this does not create a new instance, so
+     * it can be used to validate identity (and check reconnection details) before issuing an instance.
+     */
+    public async resolveAppId(identityUrl: string): Promise<string | undefined> {
+        await this.loadDirectoryPromise;
+
+        const application = await this.resolveAppIdentity(identityUrl);
+
+        return isFullyQualifiedAppId(application?.appId) ? application?.appId : undefined;
     }
 
     /**

--- a/projects/fdc3-web/src/contracts.ts
+++ b/projects/fdc3-web/src/contracts.ts
@@ -98,9 +98,11 @@ export type EventMessage =
 
 export type HandshakeMessage =
     | BrowserTypes.WebConnectionProtocol1Hello
+    | BrowserTypes.WebConnectionProtocol2LoadURL
     | BrowserTypes.WebConnectionProtocol3Handshake
     | BrowserTypes.WebConnectionProtocol4ValidateAppIdentity
-    | BrowserTypes.WebConnectionProtocol5ValidateAppIdentitySuccessResponse;
+    | BrowserTypes.WebConnectionProtocol5ValidateAppIdentitySuccessResponse
+    | BrowserTypes.WebConnectionProtocol5ValidateAppIdentityFailedResponse;
 
 export type UIProviderFactory = (agent: Promise<FinosDesktopAgent>) => Promise<IUIProvider>;
 export type AppResolverFactory = (agent: Promise<FinosDesktopAgent>) => Promise<IAppResolver>;
@@ -113,7 +115,11 @@ export type Message = RequestMessage | ResponseMessage | EventMessage | Handshak
  */
 export type IRootOutgoingMessageEnvelope = {
     channelIds: [string, ...string[]];
-    payload: ResponseMessage | EventMessage | BrowserTypes.WebConnectionProtocol5ValidateAppIdentitySuccessResponse;
+    payload:
+        | ResponseMessage
+        | EventMessage
+        | BrowserTypes.WebConnectionProtocol5ValidateAppIdentitySuccessResponse
+        | BrowserTypes.WebConnectionProtocol5ValidateAppIdentityFailedResponse;
 };
 
 /**
@@ -130,6 +136,12 @@ export interface IRootIncomingMessageEnvelope<
      * Indicates which channel (which maps to a given proxy agent) the message was received from
      */
     channelId: string;
+    /**
+     * The origin of the window/frame that initiated this connection (captured from the WCP1Hello
+     * MessageEvent). Used to validate app identity. May be undefined for messaging providers that
+     * cannot determine the origin (e.g. loopback from the root agent itself).
+     */
+    origin?: string;
 }
 
 /**
@@ -146,7 +158,11 @@ export type IProxyOutgoingMessageEnvelope = {
  * A Request message sent from a proxy agent. No target information is required as all request messages go to the root
  */
 export type IProxyIncomingMessageEnvelope = {
-    payload: ResponseMessage | EventMessage | BrowserTypes.WebConnectionProtocol5ValidateAppIdentitySuccessResponse;
+    payload:
+        | ResponseMessage
+        | EventMessage
+        | BrowserTypes.WebConnectionProtocol5ValidateAppIdentitySuccessResponse
+        | BrowserTypes.WebConnectionProtocol5ValidateAppIdentityFailedResponse;
 };
 
 /**

--- a/projects/fdc3-web/src/get-agent/get-agent.spec.ts
+++ b/projects/fdc3-web/src/get-agent/get-agent.spec.ts
@@ -228,7 +228,7 @@ describe('getAgent', () => {
         expect(fdc3ReadyListenersAdded.length).toBe(fdc3ReadyListenersRemoved.length);
     });
 
-    it('should handle failover function returning a Window object', async () => {
+    it('should restart the WCP handshake against a Window returned by the failover function', async () => {
         // Setup - ensure no agent is available
         (window as any).fdc3 = undefined;
         resetCachedPromise();
@@ -239,6 +239,8 @@ describe('getAgent', () => {
             public static [Symbol.hasInstance]() {
                 return true;
             }
+
+            public postMessage = vi.fn();
         }
         // Create a mock Window object and a failover function that returns it
         const mockWindow = new Window();
@@ -252,8 +254,14 @@ describe('getAgent', () => {
             timeoutMs: 10, // Use a short timeout for testing
         });
 
-        // Act & Assert - verify getAgent rejects with the expected error message
-        await expect(agentPromise).rejects.toEqual('Failover Window result not currently supported');
+        // Act & Assert - the window never completes a handshake, so getAgent rejects with ErrorOnConnect.
+        await expect(agentPromise).rejects.toEqual(AgentError.ErrorOnConnect);
+
+        // Verify a WCP1Hello was posted to the window returned by the failover function.
+        expect(mockWindow.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'WCP1Hello' }),
+            expect.objectContaining({ targetOrigin: '*' }),
+        );
 
         // Restore the original Window object
         (global as any).Window = originalWindow;
@@ -317,6 +325,55 @@ describe('getAgent', () => {
 
         // Act & Assert - verify getAgent rejects with AgentNotFound
         await expect(getAgent({ timeoutMs: 10 })).rejects.toBe(AgentError.AgentNotFound);
+    });
+
+    it('should reject with AccessDenied when the Desktop Agent rejects the app identity', async () => {
+        // Setup - ensure no preload agent is available
+        (window as any).fdc3 = undefined;
+        resetCachedPromise();
+
+        // A real MessageChannel is used to model the port handed over in the WCP3Handshake.
+        const channel = new MessageChannel();
+        channel.port2.start();
+
+        // The Desktop Agent end responds to the WCP4ValidateAppIdentity with a failed response.
+        channel.port2.addEventListener('message', (event: MessageEvent) => {
+            if (event.data?.type === 'WCP4ValidateAppIdentity') {
+                channel.port2.postMessage({
+                    type: 'WCP5ValidateAppIdentityFailedResponse',
+                    meta: {
+                        connectionAttemptUuid: event.data.meta.connectionAttemptUuid,
+                        timestamp: new Date(),
+                    },
+                    payload: { message: 'identity rejected' },
+                });
+            }
+        });
+
+        // A parent window that completes the handshake, transferring port1 to the app.
+        const mockParent = {
+            postMessage: (message: any) => {
+                if (message.type === 'WCP1Hello') {
+                    window.dispatchEvent(
+                        new MessageEvent('message', {
+                            data: {
+                                type: 'WCP3Handshake',
+                                meta: {
+                                    connectionAttemptUuid: message.meta.connectionAttemptUuid,
+                                    timestamp: new Date(),
+                                },
+                                payload: { fdc3Version: '2.2.0', channelSelectorUrl: false, intentResolverUrl: false },
+                            },
+                            ports: [channel.port1],
+                        }),
+                    );
+                }
+            },
+        };
+        vi.spyOn(window, 'parent', 'get').mockReturnValue(mockParent as any);
+
+        // Act & Assert - identity validation fails, so getAgent rejects with AccessDenied.
+        await expect(getAgent({ timeoutMs: 1000 })).rejects.toBe(AgentError.AccessDenied);
     });
 
     it('should clear timeout when agent discovery fails', async () => {

--- a/projects/fdc3-web/src/get-agent/get-agent.ts
+++ b/projects/fdc3-web/src/get-agent/get-agent.ts
@@ -12,10 +12,11 @@ import {
     AgentError,
     BrowserTypes,
     DesktopAgent,
-    GetAgentLogLevels,
+    DesktopAgentDetails,
     GetAgentParams,
     GetAgentType,
     LogLevel,
+    WebDesktopAgentType,
 } from '@finos/fdc3';
 import { DesktopAgentFactory } from '../agent/index.js';
 import { DEFAULT_AGENT_DISCOVERY_TIMEOUT, FDC3_READY_EVENT } from '../constants.js';
@@ -25,10 +26,26 @@ import {
     discoverProxyCandidates,
     generateHelloMessage,
     generateValidateIdentityMessage,
+    getDesktopAgentDetails,
+    isWCPFailedResponse,
     isWCPHandshake,
+    isWCPLoadUrl,
     isWCPSuccessResponse,
+    setDesktopAgentDetails,
 } from '../helpers/index.js';
 import { DefaultProxyMessagingProvider } from '../messaging-provider/index.js';
+
+/**
+ * Details of an established Desktop Agent Proxy connection, gathered during the discovery step of
+ * the Web Connection Protocol and consumed by the identity validation step.
+ */
+type ProxyConnection = {
+    messagePort: MessagePort;
+    handshake: BrowserTypes.WebConnectionProtocol3Handshake;
+    agentType: WebDesktopAgentType;
+    /** URL loaded into a hidden iframe to establish the connection (WCP2LoadUrl / persisted reconnection). */
+    agentUrl?: string;
+};
 
 /**
  * subsequent calls to getAgent just return this promise.
@@ -100,35 +117,53 @@ const getAgentImpl: GetAgentType = async (params?: GetAgentParams): Promise<Desk
 
     proxyLog(`getAgent called with params:`, LogLevel.DEBUG, params);
 
-    const existingAgent = await Promise.race([
-        waitForPreloadAgent(params?.timeoutMs),
-        waitForProxyAgent(params?.identityUrl, params),
-    ]);
+    const identityUrl = params?.identityUrl ?? window.location.href;
 
-    //TODO: look for details of existing agent in session storage
+    // WCP Step 1.1: Check SessionStorage for details of a prior connection (e.g. before a navigation
+    // or refresh event). When present these are used to reconnect to the same agent and reclaim the
+    // same instanceId, and to limit discovery to the previously used mechanism.
+    const storedDetails = getDesktopAgentDetails(identityUrl);
+    if (storedDetails != null) {
+        connectionLog(`found persisted DesktopAgentDetails for ${identityUrl}`, LogLevel.DEBUG, storedDetails);
+    }
+
+    const existingAgent = await discoverAgent(identityUrl, params, storedDetails);
 
     if (existingAgent != null) {
         return existingAgent;
     }
 
     if (typeof params?.failover === 'function') {
-        proxyLog(`calling failover function`, LogLevel.INFO);
-        // a failover function has been provided.
-        const failoverResult = await params.failover(params);
-
-        if (failoverResult instanceof Window) {
-            proxyLog(`failover function returned a window`, LogLevel.INFO);
-            return Promise.reject(`Failover Window result not currently supported`);
-        }
-
-        proxyLog(`Failover function created agent`, LogLevel.INFO);
-
-        return failoverResult;
+        return runFailover(identityUrl, params, storedDetails);
     }
 
     proxyLog(`rejecting as no agent found and no failover function provided`, LogLevel.ERROR);
     return Promise.reject(AgentError.AgentNotFound);
 };
+
+/**
+ * Attempts to discover a Desktop Agent, limiting the discovery mechanism to the one previously used
+ * when reconnecting (per WCP step 1.2).
+ */
+async function discoverAgent(
+    identityUrl: string,
+    params: GetAgentParams | undefined,
+    storedDetails: DesktopAgentDetails | undefined,
+): Promise<DesktopAgent | undefined> {
+    switch (storedDetails?.agentType) {
+        case WebDesktopAgentType.Preload:
+            return waitForPreloadAgent(params?.timeoutMs);
+        case WebDesktopAgentType.ProxyParent:
+        case WebDesktopAgentType.ProxyUrl:
+            return waitForProxyAgent(identityUrl, params, storedDetails);
+        default:
+            // No (or non-discovery) prior connection - look for both interface types in parallel.
+            return Promise.race([
+                waitForPreloadAgent(params?.timeoutMs),
+                waitForProxyAgent(identityUrl, params, storedDetails),
+            ]);
+    }
+}
 
 // timeout reference so we can clean it up later
 let fdc3ReadyTimeOut: number | undefined;
@@ -200,38 +235,266 @@ function waitForPreloadAgent(optionalTimeout?: number): Promise<DesktopAgent | u
 let windowHelloListeners: ((event: MessageEvent) => void)[] | undefined;
 
 /**
- * Attempts to locate a parent DesktopAgent and establish communication with it
+ * Attempts to locate a parent DesktopAgent and establish communication with it.
+ * Resolves to undefined if no Desktop Agent Proxy is discovered within the timeout, allowing the
+ * caller to fall back to a failover function or reject with AgentNotFound.
  */
-async function waitForProxyAgent(identityUrl?: string, params?: GetAgentParams): Promise<DesktopAgent> {
+async function waitForProxyAgent(
+    identityUrl: string,
+    params?: GetAgentParams,
+    storedDetails?: DesktopAgentDetails,
+): Promise<DesktopAgent | undefined> {
     connectionLog(`waitForProxyAgent called`, LogLevel.DEBUG);
-    const candidates = discoverProxyCandidates();
 
-    windowHelloListeners = [];
+    windowHelloListeners = windowHelloListeners ?? [];
 
-    const helloMessage = generateHelloMessage(identityUrl);
+    const helloMessage = generateHelloMessage(identityUrl, {
+        channelSelector: params?.channelSelector,
+        intentResolver: params?.intentResolver,
+    });
 
-    connectionLog(`${candidates.length} candidates found`, LogLevel.DEBUG, candidates);
+    const connection = await discoverProxyConnection(helloMessage, params, storedDetails);
 
-    const messagePort = await Promise.race(candidates.map(candidate => attemptHandshake(helloMessage, candidate)));
+    if (connection == null) {
+        connectionLog(`no Desktop Agent Proxy discovered within timeout`, LogLevel.INFO);
+        return undefined;
+    }
+
     connectionLog(`messagePort received`, LogLevel.DEBUG);
 
     cleanUp();
 
-    return createProxyAgent(helloMessage.meta.connectionAttemptUuid, messagePort, identityUrl, params?.logLevels);
+    return createProxyAgent(helloMessage.meta.connectionAttemptUuid, connection, identityUrl, params, storedDetails);
 }
 
 /**
- * Sets up communication with root DesktopAgent by performing handshake and creating a new ProxyDesktopAgent
+ * Discovers a Desktop Agent Proxy connection, racing all candidate parent windows/frames against a
+ * discovery timeout. If the persisted details indicate a previously loaded agent URL, discovery is
+ * skipped and the URL is loaded directly into a hidden iframe (per WCP step 1.2).
+ */
+function discoverProxyConnection(
+    helloMessage: BrowserTypes.WebConnectionProtocol1Hello,
+    params?: GetAgentParams,
+    storedDetails?: DesktopAgentDetails,
+): Promise<ProxyConnection | undefined> {
+    const timeoutInMs = params?.timeoutMs ?? DEFAULT_AGENT_DISCOVERY_TIMEOUT;
+
+    return new Promise<ProxyConnection | undefined>((resolve, reject) => {
+        const timeout = setTimeout(() => resolve(undefined), timeoutInMs) as any;
+
+        const onConnected = (connection: ProxyConnection): void => {
+            clearTimeout(timeout);
+            resolve(connection);
+        };
+        const onError = (error: unknown): void => {
+            clearTimeout(timeout);
+            reject(error);
+        };
+
+        if (storedDetails?.agentUrl != null) {
+            // Reconnecting to a previously loaded agent URL - skip discovery and load it directly.
+            connectToAgentUrl(helloMessage, storedDetails.agentUrl).then(onConnected, onError);
+            return;
+        }
+
+        const candidates = discoverProxyCandidates();
+        connectionLog(`${candidates.length} candidates found`, LogLevel.DEBUG, candidates);
+
+        // Accept the first candidate to complete a handshake. Non-responding candidates simply never
+        // resolve and are cleaned up when the discovery timeout fires.
+        candidates.forEach(candidate => connectToProxyTarget(helloMessage, candidate).then(onConnected, onError));
+    });
+}
+
+/**
+ * Establishes communication with a single candidate window/frame.
+ * Sends a WCP1Hello and resolves once a WCP3Handshake (with MessagePort) is received. If the
+ * candidate instead responds with a WCP2LoadUrl, the supplied URL is loaded into a hidden iframe and
+ * the handshake is completed against the iframe.
+ */
+async function connectToProxyTarget(
+    helloMessage: BrowserTypes.WebConnectionProtocol1Hello,
+    candidate: Window,
+): Promise<ProxyConnection> {
+    const response = await awaitWcpResponse(helloMessage, candidate);
+
+    if (isWCPHandshake(response.data)) {
+        return { messagePort: response.ports[0], handshake: response.data, agentType: WebDesktopAgentType.ProxyParent };
+    }
+
+    // WCP2LoadUrl: load the provided URL into a hidden iframe and restart the protocol against it.
+    connectionLog(`WCP2LoadUrl received, loading agent URL into hidden iframe`, LogLevel.INFO);
+    return connectToAgentUrl(
+        helloMessage,
+        (response.data as BrowserTypes.WebConnectionProtocol2LoadURL).payload.iframeUrl,
+    );
+}
+
+/**
+ * Loads an agent URL into a hidden iframe and completes the WCP handshake against it.
+ */
+async function connectToAgentUrl(
+    helloMessage: BrowserTypes.WebConnectionProtocol1Hello,
+    agentUrl: string,
+): Promise<ProxyConnection> {
+    const iframeWindow = await loadHiddenIframe(agentUrl);
+
+    // Only a WCP3Handshake is valid here - a hidden agent iframe must not send another WCP2LoadUrl.
+    const response = await awaitWcpResponse(helloMessage, iframeWindow, true);
+
+    return {
+        messagePort: response.ports[0],
+        handshake: response.data as BrowserTypes.WebConnectionProtocol3Handshake,
+        agentType: WebDesktopAgentType.ProxyUrl,
+        agentUrl,
+    };
+}
+
+/**
+ * Posts a WCP1Hello to the target window and resolves with the first correct response.
+ * Correct responses are WCP3Handshake (with a MessagePort) or, unless handshakeOnly is set,
+ * WCP2LoadUrl - both must quote the connectionAttemptUuid from the original WCP1Hello.
+ */
+function awaitWcpResponse(
+    helloMessage: BrowserTypes.WebConnectionProtocol1Hello,
+    targetWindow: Window,
+    handshakeOnly: boolean = false,
+): Promise<MessageEvent> {
+    return new Promise<MessageEvent>(resolve => {
+        if (windowHelloListeners == null) {
+            // if there is no array to record our listeners assume a connection has already been made
+            return;
+        }
+
+        const eventListener = (event: MessageEvent): void => {
+            if (event.data?.meta?.connectionAttemptUuid !== helloMessage.meta.connectionAttemptUuid) {
+                return;
+            }
+
+            if (isWCPHandshake(event.data) && event.ports[0] != null) {
+                connectionLog(`handshake response received`, LogLevel.INFO);
+                resolve(event);
+            } else if (!handshakeOnly && isWCPLoadUrl(event.data)) {
+                connectionLog(`load url response received`, LogLevel.INFO);
+                resolve(event);
+            }
+        };
+
+        // keep track of event listeners
+        windowHelloListeners.push(eventListener);
+        window.addEventListener('message', eventListener);
+
+        targetWindow.postMessage(helloMessage, { targetOrigin: '*' });
+    });
+}
+
+/**
+ * Creates a hidden iframe pointing at the supplied URL, resolving with its contentWindow once loaded.
+ * Rejects with AgentError.ErrorOnConnect if the iframe fails to provide a contentWindow.
+ */
+function loadHiddenIframe(url: string): Promise<WindowProxy> {
+    return new Promise<WindowProxy>((resolve, reject) => {
+        const iframe = document.createElement('iframe');
+        iframe.onload = () => {
+            if (iframe.contentWindow != null) {
+                resolve(iframe.contentWindow);
+            } else {
+                reject(AgentError.ErrorOnConnect);
+            }
+        };
+        iframe.onerror = () => reject(AgentError.ErrorOnConnect);
+        iframe.src = url;
+        iframe.style.width = '0';
+        iframe.style.height = '0';
+        iframe.style.visibility = 'hidden';
+        iframe.ariaHidden = 'true';
+        document.body.appendChild(iframe);
+    });
+}
+
+/**
+ * Runs the application supplied failover function (per WCP step 1.2, sub-step 6).
+ * The function may resolve to a DesktopAgent (returned directly) or a WindowProxy (against which the
+ * WCP handshake is restarted). Any other result rejects with AgentError.InvalidFailover.
+ */
+async function runFailover(
+    identityUrl: string,
+    params: GetAgentParams,
+    storedDetails: DesktopAgentDetails | undefined,
+): Promise<DesktopAgent> {
+    proxyLog(`calling failover function`, LogLevel.INFO);
+    const failoverResult = await params.failover!(params);
+
+    if (failoverResult instanceof Window) {
+        proxyLog(`failover function returned a window, restarting WCP handshake against it`, LogLevel.INFO);
+
+        windowHelloListeners = windowHelloListeners ?? [];
+        const helloMessage = generateHelloMessage(identityUrl, {
+            channelSelector: params.channelSelector,
+            intentResolver: params.intentResolver,
+        });
+
+        // Restart the handshake against the supplied window, bounded by the discovery timeout. A
+        // window that never completes the handshake rejects with ErrorOnConnect (per WCP step 1.2).
+        const connection = await withTimeout(
+            connectToProxyTarget(helloMessage, failoverResult),
+            params.timeoutMs ?? DEFAULT_AGENT_DISCOVERY_TIMEOUT,
+            AgentError.ErrorOnConnect,
+        );
+        cleanUp();
+
+        return createProxyAgent(
+            helloMessage.meta.connectionAttemptUuid,
+            { ...connection, agentType: WebDesktopAgentType.Failover },
+            identityUrl,
+            params,
+            storedDetails,
+        );
+    }
+
+    if (isDesktopAgent(failoverResult)) {
+        proxyLog(`Failover function created agent`, LogLevel.INFO);
+        return failoverResult;
+    }
+
+    proxyLog(`failover function returned an unsupported result type`, LogLevel.ERROR, failoverResult);
+    return Promise.reject(AgentError.InvalidFailover);
+}
+
+/**
+ * Rejects with the supplied error if the wrapped promise does not settle within timeoutMs.
+ */
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, error: unknown): Promise<T> {
+    return Promise.race([promise, new Promise<T>((_, reject) => setTimeout(() => reject(error), timeoutMs))]);
+}
+
+/**
+ * Type guard distinguishing a DesktopAgent returned by a failover function from other (invalid)
+ * return values. A WindowProxy is handled separately before this is reached, so any non-null object
+ * is treated as a DesktopAgent and anything else (null, primitives) is an invalid failover result.
+ */
+function isDesktopAgent(value: unknown): value is DesktopAgent {
+    return value != null && typeof value === 'object';
+}
+
+/**
+ * Sets up communication with root DesktopAgent by validating identity and creating a new ProxyDesktopAgent
  */
 async function createProxyAgent(
     connectionAttemptUuid: string,
-    messagePort: MessagePort,
-    identityUrl?: string,
-    logLevels?: GetAgentLogLevels,
+    connection: ProxyConnection,
+    identityUrl: string,
+    params?: GetAgentParams,
+    storedDetails?: DesktopAgentDetails,
 ): Promise<DesktopAgent> {
     connectionLog(`createProxyAgent called`, LogLevel.DEBUG, { connectionAttemptUuid, identityUrl });
-    const messagingProvider = new DefaultProxyMessagingProvider(messagePort);
-    const appValidationResponse = await performAppValidation(messagingProvider, connectionAttemptUuid, identityUrl);
+    const messagingProvider = new DefaultProxyMessagingProvider(connection.messagePort);
+    const appValidationResponse = await performAppValidation(
+        messagingProvider,
+        connectionAttemptUuid,
+        identityUrl,
+        storedDetails,
+    );
 
     const proxyAgent = new DesktopAgentFactory().createProxy({
         appIdentifier: {
@@ -239,7 +502,21 @@ async function createProxyAgent(
             instanceId: appValidationResponse.payload.instanceId,
         },
         messagingProviderFactory: () => Promise.resolve(messagingProvider),
-        logLevels: logLevels,
+        logLevels: params?.logLevels,
+    });
+
+    // Inject any channel selector / intent resolver UIs the Desktop Agent asked us to provide.
+    injectUserInterfaces(connection.handshake);
+
+    // WCP Step 3: persist connection details so a subsequent navigation/refresh can reconnect.
+    setDesktopAgentDetails({
+        agentType: connection.agentType,
+        identityUrl,
+        actualUrl: window.location.href,
+        agentUrl: connection.agentUrl,
+        appId: appValidationResponse.payload.appId,
+        instanceId: appValidationResponse.payload.instanceId,
+        instanceUuid: appValidationResponse.payload.instanceUuid,
     });
 
     connectionLog(`proxy agent created`, LogLevel.DEBUG, proxyAgent);
@@ -248,27 +525,61 @@ async function createProxyAgent(
 }
 
 /**
- * Sends a WebConnectionProtocol4ValidateAppIdentity to root agent and waits for the response
+ * Injects hidden iframes for the channel selector / intent resolver UIs when the Desktop Agent
+ * supplies a URL for them in the WCP3Handshake. A boolean `true` indicates the reference UI should
+ * be used; as no default reference UI URL is bundled, this is logged and skipped.
+ */
+function injectUserInterfaces(handshake: BrowserTypes.WebConnectionProtocol3Handshake): void {
+    injectUserInterface('channel selector', handshake.payload.channelSelectorUrl);
+    injectUserInterface('intent resolver', handshake.payload.intentResolverUrl);
+}
+
+function injectUserInterface(name: string, url: boolean | string): void {
+    if (typeof url === 'string') {
+        connectionLog(`injecting ${name} UI iframe`, LogLevel.DEBUG, url);
+        loadHiddenIframe(url).catch(error => connectionLog(`failed to load ${name} UI iframe`, LogLevel.ERROR, error));
+    } else if (url === true) {
+        connectionLog(`${name} reference UI requested but no default URL is configured; skipping`, LogLevel.WARN);
+    }
+}
+
+/**
+ * Sends a WebConnectionProtocol4ValidateAppIdentity to root agent and waits for the response.
+ * Resolves with the success response, or rejects with AgentError.AccessDenied if the Desktop Agent
+ * rejects the app's identity (WCP5ValidateAppIdentityFailedResponse).
  */
 function performAppValidation(
     messagingProvider: IProxyMessagingProvider,
     connectionAttemptUuid: string,
     identityUrl?: string,
+    storedDetails?: DesktopAgentDetails,
 ): Promise<BrowserTypes.WebConnectionProtocol5ValidateAppIdentitySuccessResponse> {
     connectionLog(`performAppValidation called`, LogLevel.DEBUG, { connectionAttemptUuid, identityUrl });
-    const validateIdentityMessage = generateValidateIdentityMessage(connectionAttemptUuid, identityUrl);
+    const validateIdentityMessage = generateValidateIdentityMessage(
+        connectionAttemptUuid,
+        identityUrl,
+        storedDetails?.instanceId,
+        storedDetails?.instanceUuid,
+    );
 
     const responsePromise = new Promise<BrowserTypes.WebConnectionProtocol5ValidateAppIdentitySuccessResponse>(
-        resolve => {
+        (resolve, reject) => {
             messagingProvider.addResponseHandler(message => {
+                const payload = message.payload;
+
                 if (
-                    isWCPSuccessResponse(message.payload) &&
-                    validateIdentityMessage.meta.connectionAttemptUuid === message.payload.meta.connectionAttemptUuid
+                    isWCPSuccessResponse(payload) &&
+                    payload.meta.connectionAttemptUuid === validateIdentityMessage.meta.connectionAttemptUuid
                 ) {
-                    connectionLog(`app validation response received`, LogLevel.DEBUG, message.payload);
-                    resolve(message.payload);
+                    connectionLog(`app validation response received`, LogLevel.DEBUG, payload);
+                    resolve(payload);
+                } else if (
+                    isWCPFailedResponse(payload) &&
+                    payload.meta.connectionAttemptUuid === validateIdentityMessage.meta.connectionAttemptUuid
+                ) {
+                    connectionLog(`app validation failed`, LogLevel.ERROR, payload);
+                    reject(AgentError.AccessDenied);
                 }
-                //TODO: handle error response
             });
         },
     );
@@ -278,40 +589,6 @@ function performAppValidation(
     });
 
     return responsePromise;
-}
-
-/**
- * Tries to establish communication with specified window
- * If communication is established a MessagePort is returned
- * @param window
- */
-function attemptHandshake(
-    helloMessage: BrowserTypes.WebConnectionProtocol1Hello,
-    candidate: Window,
-): Promise<MessagePort> {
-    return new Promise<MessagePort>(resolve => {
-        if (windowHelloListeners == null) {
-            // if there is no array to record our listeners for later tidy up assume that an agent has already been located and return
-            return;
-        }
-
-        const eventListener = (event: MessageEvent): void => {
-            //TODO: handle WebConnectionProtocol2LoadURL messages as well
-            if (
-                isWCPHandshake(event.data) &&
-                event.data.meta.connectionAttemptUuid === helloMessage.meta.connectionAttemptUuid &&
-                event.ports[0] != null
-            ) {
-                connectionLog(`handshake response received`, LogLevel.INFO);
-                resolve(event.ports[0]);
-            }
-        };
-        candidate.postMessage(helloMessage, { targetOrigin: '*' });
-
-        // keep track of event listeners
-        windowHelloListeners.push(eventListener);
-        window.addEventListener('message', eventListener);
-    });
 }
 
 /**

--- a/projects/fdc3-web/src/helpers/finos-type-predicate.helper.spec.ts
+++ b/projects/fdc3-web/src/helpers/finos-type-predicate.helper.spec.ts
@@ -307,6 +307,18 @@ describe('finos-type-predicate.helper', () => {
         expect(typePredicates.isWCPHandshake(validMessage)).toBe(true);
     });
 
+    it('should identify valid WCP Load Url messages', () => {
+        const validMessage = { type: 'WCP2LoadUrl' };
+        expect(typePredicates.isWCPLoadUrl(validMessage)).toBe(true);
+        expect(typePredicates.isWCPLoadUrl({ type: 'WCP3Handshake' })).toBe(false);
+    });
+
+    it('should identify valid WCP Failed Response messages', () => {
+        const validMessage = { type: 'WCP5ValidateAppIdentityFailedResponse' };
+        expect(typePredicates.isWCPFailedResponse(validMessage)).toBe(true);
+        expect(typePredicates.isWCPFailedResponse({ type: 'WCP5ValidateAppIdentityResponse' })).toBe(false);
+    });
+
     it('should identify valid WCP Goodbye messages', () => {
         const validMessage = { type: 'WCP6Goodbye' };
         expect(typePredicates.isWCPGoodbye(validMessage)).toBe(true);

--- a/projects/fdc3-web/src/helpers/finos-type-predicate.helper.ts
+++ b/projects/fdc3-web/src/helpers/finos-type-predicate.helper.ts
@@ -431,6 +431,19 @@ export function isWCPSuccessResponse(
     );
 }
 
+export function isWCPFailedResponse(
+    value: any,
+): value is BrowserTypes.WebConnectionProtocol5ValidateAppIdentityFailedResponse {
+    return (
+        (value as BrowserTypes.WebConnectionProtocol5ValidateAppIdentityFailedResponse).type ===
+        'WCP5ValidateAppIdentityFailedResponse'
+    );
+}
+
+export function isWCPLoadUrl(value: any): value is BrowserTypes.WebConnectionProtocol2LoadURL {
+    return (value as BrowserTypes.WebConnectionProtocol2LoadURL).type === 'WCP2LoadUrl';
+}
+
 function neverCheck(_value: never): false {
     return false;
 }

--- a/projects/fdc3-web/src/helpers/index.ts
+++ b/projects/fdc3-web/src/helpers/index.ts
@@ -21,4 +21,5 @@ export * from './get-host-manifest.helper.js';
 export * from './event-type.helper.js';
 export * from './messages.helper.js';
 export * from './discover-proxy-candidates.helper.js';
+export * from './session-storage.helper.js';
 export * from './log.helper.js';

--- a/projects/fdc3-web/src/helpers/messages.helper.spec.ts
+++ b/projects/fdc3-web/src/helpers/messages.helper.spec.ts
@@ -250,6 +250,8 @@ describe(`messages.helper`, () => {
                     actualUrl: 'https://test.com',
                     fdc3Version: FDC3_VERSION,
                     identityUrl: 'https://test.com',
+                    channelSelector: true,
+                    intentResolver: true,
                 },
                 type: 'WCP1Hello',
             });
@@ -265,9 +267,18 @@ describe(`messages.helper`, () => {
                     actualUrl: 'https://test.com',
                     fdc3Version: FDC3_VERSION,
                     identityUrl: identityUrl,
+                    channelSelector: true,
+                    intentResolver: true,
                 },
                 type: 'WCP1Hello',
             });
+        });
+
+        it('should pass through the channelSelector and intentResolver opt-out flags', () => {
+            const helloMessage = generateHelloMessage(undefined, { channelSelector: false, intentResolver: false });
+
+            expect(helloMessage.payload.channelSelector).toBe(false);
+            expect(helloMessage.payload.intentResolver).toBe(false);
         });
     });
 

--- a/projects/fdc3-web/src/helpers/messages.helper.ts
+++ b/projects/fdc3-web/src/helpers/messages.helper.ts
@@ -88,13 +88,19 @@ export function createEvent<T extends BrowserTypes.AgentEventMessage>(
     return event as T;
 }
 
-export function generateHelloMessage(identityUrl?: string): BrowserTypes.WebConnectionProtocol1Hello {
+export function generateHelloMessage(
+    identityUrl?: string,
+    options?: { channelSelector?: boolean; intentResolver?: boolean; connectionAttemptUuid?: string },
+): BrowserTypes.WebConnectionProtocol1Hello {
     const helloMessage: BrowserTypes.WebConnectionProtocol1Hello = {
-        meta: { timestamp: getTimestamp(), connectionAttemptUuid: generateUUID() },
+        meta: { timestamp: getTimestamp(), connectionAttemptUuid: options?.connectionAttemptUuid ?? generateUUID() },
         payload: {
             actualUrl: window.location.href,
             fdc3Version: FDC3_VERSION,
             identityUrl: identityUrl ?? window.location.href,
+            // Defaults to `true` per the WCP spec - an app only opts out of the UIs by passing `false`.
+            channelSelector: options?.channelSelector ?? true,
+            intentResolver: options?.intentResolver ?? true,
         },
         type: 'WCP1Hello',
     };
@@ -112,6 +118,10 @@ export function generateHandshakeResponseMessage(
             timestamp: getTimestamp(),
         },
         payload: {
+            // This Desktop Agent handles channel selection / intent resolution itself and does not ask
+            // the app to inject the reference UIs, so both URLs are returned as `false`. The app's
+            // requested flags (message.payload.channelSelector / intentResolver) are still respected by
+            // the getAgent() implementation, which only injects a UI iframe when a URL is supplied here.
             channelSelectorUrl: false,
             fdc3Version: FDC3_VERSION,
             intentResolverUrl: false,

--- a/projects/fdc3-web/src/helpers/session-storage.helper.spec.ts
+++ b/projects/fdc3-web/src/helpers/session-storage.helper.spec.ts
@@ -1,0 +1,64 @@
+/* Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License. */
+
+import { DESKTOP_AGENT_SESSION_STORAGE_KEY_PREFIX, DesktopAgentDetails, WebDesktopAgentType } from '@finos/fdc3';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getDesktopAgentDetails, setDesktopAgentDetails } from './session-storage.helper.js';
+
+describe('session-storage.helper', () => {
+    const detailsForApp = (identityUrl: string): DesktopAgentDetails => ({
+        agentType: WebDesktopAgentType.ProxyParent,
+        identityUrl,
+        actualUrl: identityUrl,
+        appId: 'my-app-id',
+        instanceId: 'instance-1',
+        instanceUuid: 'uuid-1',
+    });
+
+    beforeEach(() => {
+        window.sessionStorage.clear();
+    });
+
+    it('should return undefined when no details have been persisted', () => {
+        expect(getDesktopAgentDetails('https://my-app.com')).toBeUndefined();
+    });
+
+    it('should persist and retrieve details keyed by identityUrl', () => {
+        const details = detailsForApp('https://my-app.com');
+        setDesktopAgentDetails(details);
+
+        expect(getDesktopAgentDetails('https://my-app.com')).toEqual(details);
+        expect(getDesktopAgentDetails('https://other-app.com')).toBeUndefined();
+    });
+
+    it('should store records for multiple identity urls without collision', () => {
+        const first = detailsForApp('https://app-one.com');
+        const second = detailsForApp('https://app-two.com');
+
+        setDesktopAgentDetails(first);
+        setDesktopAgentDetails(second);
+
+        expect(getDesktopAgentDetails('https://app-one.com')).toEqual(first);
+        expect(getDesktopAgentDetails('https://app-two.com')).toEqual(second);
+    });
+
+    it('should store details under the standard session storage key', () => {
+        setDesktopAgentDetails(detailsForApp('https://my-app.com'));
+
+        const raw = window.sessionStorage.getItem(DESKTOP_AGENT_SESSION_STORAGE_KEY_PREFIX);
+        expect(raw).not.toBeNull();
+        expect(JSON.parse(raw!)['https://my-app.com'].appId).toBe('my-app-id');
+    });
+
+    it('should return undefined when stored data is corrupt', () => {
+        window.sessionStorage.setItem(DESKTOP_AGENT_SESSION_STORAGE_KEY_PREFIX, '{ not json');
+        expect(getDesktopAgentDetails('https://my-app.com')).toBeUndefined();
+    });
+});

--- a/projects/fdc3-web/src/helpers/session-storage.helper.ts
+++ b/projects/fdc3-web/src/helpers/session-storage.helper.ts
@@ -1,0 +1,55 @@
+/* Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License. */
+
+import { DESKTOP_AGENT_SESSION_STORAGE_KEY_PREFIX, DesktopAgentDetails, SessionStorageFormat } from '@finos/fdc3';
+
+/**
+ * Helpers for persisting and retrieving `DesktopAgentDetails` records in SessionStorage as
+ * described by steps 1.1 and 3 of the FDC3 Web Connection Protocol. Records are keyed by the
+ * `identityUrl` of the app so that multiple apps (or identities) sharing a window do not collide.
+ *
+ * @see https://fdc3.finos.org/docs/api/specs/webConnectionProtocol
+ */
+
+function readStore(): SessionStorageFormat {
+    try {
+        const raw = window.sessionStorage.getItem(DESKTOP_AGENT_SESSION_STORAGE_KEY_PREFIX);
+        if (raw == null) {
+            return {};
+        }
+        return JSON.parse(raw) as SessionStorageFormat;
+    } catch {
+        // SessionStorage may be unavailable (e.g. sandboxed iframe) or contain corrupt data.
+        return {};
+    }
+}
+
+/**
+ * Returns any previously persisted connection details for the supplied identity URL, or undefined
+ * if none exist (i.e. this is the first connection attempt within this window's lifetime).
+ */
+export function getDesktopAgentDetails(identityUrl: string): DesktopAgentDetails | undefined {
+    return readStore()[identityUrl];
+}
+
+/**
+ * Persists connection details for the supplied identity URL so that a subsequent navigation or
+ * refresh event can reconnect to the same Desktop Agent and reclaim the same instanceId.
+ */
+export function setDesktopAgentDetails(details: DesktopAgentDetails): void {
+    try {
+        const store = readStore();
+        store[details.identityUrl] = details;
+        window.sessionStorage.setItem(DESKTOP_AGENT_SESSION_STORAGE_KEY_PREFIX, JSON.stringify(store));
+    } catch {
+        // SessionStorage may be unavailable; persistence is best-effort and its absence only means
+        // that a future reconnection will be treated as a brand new connection.
+    }
+}

--- a/projects/fdc3-web/src/helpers/url-helper.ts
+++ b/projects/fdc3-web/src/helpers/url-helper.ts
@@ -60,6 +60,31 @@ export function decodeUUUrl<T extends Record<string, string>>(
 }
 
 /**
+ * Validates, per WCP step 2.1, that the identityUrl and actualUrl provided by an app share the same
+ * origin (scheme, host and port) and, when a hello message origin is known, that it matches too.
+ * Returns false if any URL is malformed or the origins differ.
+ * @param identityUrl the URL the app uses to assert its identity
+ * @param actualUrl the app's actual current URL
+ * @param messageOrigin the origin of the WCP1Hello MessageEvent, if known
+ */
+export function appIdentityOriginsMatch(identityUrl: string, actualUrl: string, messageOrigin?: string): boolean {
+    try {
+        const identityOrigin = new URL(identityUrl).origin;
+        const actualOrigin = new URL(actualUrl).origin;
+
+        if (identityOrigin !== actualOrigin) {
+            return false;
+        }
+
+        // Only compare against the message origin when one was captured (some messaging providers,
+        // e.g. the root agent's own loopback, cannot determine it).
+        return messageOrigin == null || messageOrigin === identityOrigin;
+    } catch {
+        return false;
+    }
+}
+
+/**
  * Compares two urls and returns true if all elements (query parameters, hash, path segments) from the source url are in the comparisonUrl
  * host, port and protocol must all match as well
  * @param _sourceUrl

--- a/projects/fdc3-web/src/messaging-provider/default-root-messaging-provider.spec.ts
+++ b/projects/fdc3-web/src/messaging-provider/default-root-messaging-provider.spec.ts
@@ -129,6 +129,7 @@ describe('DefaultRootMessagingProvider', () => {
                 type: 'getInfoRequest',
             },
             channelId: mockedGeneratedUuid,
+            origin: undefined,
         };
 
         (

--- a/projects/fdc3-web/src/messaging-provider/default-root-messaging-provider.ts
+++ b/projects/fdc3-web/src/messaging-provider/default-root-messaging-provider.ts
@@ -25,6 +25,8 @@ import { generateHandshakeResponseMessage, generateUUID, isWCPHelloMessage } fro
 export class DefaultRootMessagingProvider implements IRootMessagingProvider {
     private callbacks: IncomingMessageCallback<IRootIncomingMessageEnvelope>[] = [];
     private messageChannels: Record<string, MessagePort> = {};
+    /** Origin of the WCP1Hello message for each channel, used downstream to validate app identity. */
+    private channelOrigins: Record<string, string> = {};
 
     constructor(
         windowRef: Window,
@@ -67,13 +69,14 @@ export class DefaultRootMessagingProvider implements IRootMessagingProvider {
             const messageChannel =
                 this.messageChannelFactory != null ? this.messageChannelFactory() : new MessageChannel();
             this.messageChannels[channelId] = messageChannel.port1;
+            this.channelOrigins[channelId] = message.origin;
 
             messageChannel.port1.start();
 
             // listen to incoming messages on the new channel
             messageChannel.port1.addEventListener('message', message => {
                 for (const callback of this.callbacks) {
-                    callback({ payload: message.data, channelId });
+                    callback({ payload: message.data, channelId, origin: this.channelOrigins[channelId] });
                 }
             });
 

--- a/projects/fdc3-web/src/messaging/root-message-publisher.spec.ts
+++ b/projects/fdc3-web/src/messaging/root-message-publisher.spec.ts
@@ -260,6 +260,102 @@ describe('RootMessagePublisher', () => {
                 mockRequestHandler.withFunction('handler').withParametersEqualTo(requestMessage, sourceApp),
             ).wasCalledOnce();
         });
+
+        it('should respond with a failed response when the identityUrl and actualUrl origins do not match', async () => {
+            createInstance();
+            mockDirectory.setupFunction('resolveAppId', () => Promise.resolve(sourceAppId));
+            mockDirectory.setupFunction('registerNewInstance', () =>
+                Promise.reject('registerNewInstance should not be called'),
+            );
+
+            const validationMessage: BrowserTypes.WebConnectionProtocol4ValidateAppIdentity = {
+                meta: { timestamp: mockedDate, connectionAttemptUuid: 'attempt-1' },
+                payload: { identityUrl: 'https://my-app.com', actualUrl: 'https://evil.com' },
+                type: 'WCP4ValidateAppIdentity',
+            };
+
+            const published = waitForMessage(
+                message => message.payload.type === 'WCP5ValidateAppIdentityFailedResponse',
+            );
+
+            mockRootMessagingProvider.functionCallLookup.subscribe?.[0][0]({
+                payload: validationMessage,
+                channelId: 'channelOne',
+                origin: 'https://my-app.com',
+            });
+
+            await published;
+
+            // The app should never be registered when its identity is rejected.
+            expect(mockDirectory.withFunction('registerNewInstance')).wasNotCalled();
+        });
+
+        it('should respond with a failed response when the identityUrl is not known to the agent', async () => {
+            createInstance();
+            mockDirectory.setupFunction('resolveAppId', () => Promise.resolve(undefined));
+            mockDirectory.setupFunction('registerNewInstance', () =>
+                Promise.reject('registerNewInstance should not be called'),
+            );
+
+            const validationMessage: BrowserTypes.WebConnectionProtocol4ValidateAppIdentity = {
+                meta: { timestamp: mockedDate, connectionAttemptUuid: 'attempt-1' },
+                payload: { identityUrl: 'https://unknown-app.com', actualUrl: 'https://unknown-app.com' },
+                type: 'WCP4ValidateAppIdentity',
+            };
+
+            const published = waitForMessage(
+                message => message.payload.type === 'WCP5ValidateAppIdentityFailedResponse',
+            );
+
+            mockRootMessagingProvider.functionCallLookup.subscribe?.[0][0]({
+                payload: validationMessage,
+                channelId: 'channelOne',
+                origin: 'https://unknown-app.com',
+            });
+
+            await published;
+
+            expect(mockDirectory.withFunction('registerNewInstance')).wasNotCalled();
+        });
+
+        it('should reissue the same instanceId when a known instanceUuid is presented (reconnection)', async () => {
+            const instance = createInstance();
+            instance.requestMessageHandler = mockRequestHandler.mock.handler;
+
+            const sourceApp: FullyQualifiedAppIdentifier = { appId: sourceAppId, instanceId: 'instanceOne' };
+
+            // First connection issues instanceId 'instanceOne' and an instanceUuid (also 'instanceOne' here).
+            await registerNewProxy(sourceApp, 'channelOne');
+
+            // Reconnect on a new channel, presenting the previously issued instanceId / instanceUuid.
+            const reconnectMessage: BrowserTypes.WebConnectionProtocol4ValidateAppIdentity = {
+                meta: { timestamp: mockedDate, connectionAttemptUuid: 'attempt-2' },
+                payload: {
+                    identityUrl: 'https://my-app.com',
+                    actualUrl: 'https://my-app.com',
+                    instanceId: sourceApp.instanceId,
+                    instanceUuid: sourceApp.instanceId,
+                },
+                type: 'WCP4ValidateAppIdentity',
+            };
+
+            const published = waitForMessage(message => message.payload.type === 'WCP5ValidateAppIdentityResponse');
+
+            mockRootMessagingProvider.functionCallLookup.subscribe?.[0][0]({
+                payload: reconnectMessage,
+                channelId: 'channelTwo',
+                origin: 'https://my-app.com',
+            });
+
+            await published;
+
+            // registerNewInstance must be asked to reuse the prior instanceId for the reconnection.
+            expect(
+                mockDirectory
+                    .withFunction('registerNewInstance')
+                    .withParametersEqualTo('https://my-app.com', sourceApp.instanceId),
+            ).wasCalledOnce();
+        });
     });
 
     describe('publishEvent', () => {
@@ -368,6 +464,7 @@ describe('RootMessagePublisher', () => {
 
     async function registerNewProxy(sourceApp: FullyQualifiedAppIdentifier, channelId: string): Promise<void> {
         generateUuidResult = sourceApp.instanceId;
+        mockDirectory.setupFunction('resolveAppId', () => Promise.resolve(sourceApp.appId));
         mockDirectory.setupFunction('registerNewInstance', () => {
             return Promise.resolve({
                 application: Mock.create<AppDirectoryApplication>().setup(setupProperty('appId', sourceApp.appId)).mock,
@@ -440,8 +537,8 @@ describe('RootMessagePublisher', () => {
                 connectionAttemptUuid: 'mock-connection-attempt-uuid',
             },
             payload: {
-                actualUrl: '',
-                identityUrl: '',
+                actualUrl: 'https://my-app.com',
+                identityUrl: 'https://my-app.com',
             },
             type: 'WCP4ValidateAppIdentity',
         };

--- a/projects/fdc3-web/src/messaging/root-message-publisher.ts
+++ b/projects/fdc3-web/src/messaging/root-message-publisher.ts
@@ -24,6 +24,7 @@ import {
     ResponseMessage,
 } from '../contracts.js';
 import {
+    appIdentityOriginsMatch,
     createLogger,
     generateUUID,
     getImplementationMetadata,
@@ -47,6 +48,12 @@ type RequestMessageHandler = (
 export class RootMessagePublisher implements IRootPublisher {
     private instanceIdToChannelId: Partial<Record<string, string>> = {};
     private channelIdToAppIdentifier: Partial<Record<string, FullyQualifiedAppIdentifier>> = {};
+    /**
+     * Maps the (secret) instanceUuid issued to an app instance to its identity, so that a reconnecting
+     * app (after a navigation or refresh) that presents a matching instanceUuid can be reissued the
+     * same instanceId. The instanceUuid is never shared via the FDC3 API so acts as a shared secret.
+     */
+    private instanceUuidToIdentity: Partial<Record<string, FullyQualifiedAppIdentifier>> = {};
     private log = createLogger(RootMessagePublisher, 'connection');
 
     /**
@@ -179,7 +186,7 @@ export class RootMessagePublisher implements IRootPublisher {
         >,
     ): void {
         if (isWCPValidateAppIdentity(message.payload)) {
-            this.registerNewInstance(message.payload, message.channelId);
+            this.registerNewInstance(message.payload, message.channelId, message.origin);
             return;
         }
 
@@ -189,6 +196,12 @@ export class RootMessagePublisher implements IRootPublisher {
             if (source != null) {
                 this.log(`Goodbye message received from ${source.appId} (${source.instanceId})`, LogLevel.INFO);
             }
+            // Forward the goodbye so the agent can clean up, then forget the channel mappings.
+            if (source != null) {
+                this.handleRequestMessage(message.payload, source);
+                this.forgetInstance(source, message.channelId);
+            }
+            return;
         }
 
         if (source == null) {
@@ -221,24 +234,56 @@ export class RootMessagePublisher implements IRootPublisher {
     }
 
     /**
-     * generates a new instance id and new app identifier for a new proxy agent that is performing a handshake
+     * Validates the identity of a proxy agent performing a handshake (WCP step 2) and, on success,
+     * issues (or reissues, for a reconnecting app) an instanceId and instanceUuid. On failure a
+     * WCP5ValidateAppIdentityFailedResponse is returned and no instance is registered.
      */
     private async registerNewInstance(
         validateMessage: BrowserTypes.WebConnectionProtocol4ValidateAppIdentity,
         channelId: string,
+        origin?: string,
     ): Promise<FullyQualifiedAppIdentifier | undefined> {
-        this.log('Registering new instance', LogLevel.DEBUG, { validateMessage, channelId });
+        this.log('Registering new instance', LogLevel.DEBUG, { validateMessage, channelId, origin });
 
-        const { identifier, application } = await this.directory.registerNewInstance(
-            validateMessage.payload.identityUrl,
-        );
+        const { identityUrl, actualUrl } = validateMessage.payload;
 
-        if (identifier == null) {
+        // WCP step 2.1: the identityUrl, actualUrl and the WCP1Hello message origin MUST share an origin.
+        if (!appIdentityOriginsMatch(identityUrl, actualUrl, origin)) {
+            this.log('App identity rejected: origin mismatch', LogLevel.WARN, { identityUrl, actualUrl, origin });
+            this.publishFailedResponse(
+                validateMessage,
+                channelId,
+                'Origin of identityUrl, actualUrl and connection did not match',
+            );
             return undefined;
         }
 
+        // WCP step 2.1: match the identityUrl to a known AppD record to determine the appId.
+        const appId = await this.directory.resolveAppId(identityUrl).catch(() => undefined);
+
+        if (appId == null) {
+            this.log('App identity rejected: unknown identityUrl', LogLevel.WARN, identityUrl);
+            this.publishFailedResponse(validateMessage, channelId, 'App identity could not be determined');
+            return undefined;
+        }
+
+        // WCP step 2.2: if the app presents a known instanceUuid for the same appId it is reconnecting,
+        // so reissue the same instanceId. Otherwise assign fresh identity.
+        const { instanceId: priorInstanceId, instanceUuid: priorInstanceUuid } = validateMessage.payload;
+        const priorIdentity = priorInstanceUuid != null ? this.instanceUuidToIdentity[priorInstanceUuid] : undefined;
+        const reconnecting =
+            priorIdentity != null && priorIdentity.appId === appId && priorIdentity.instanceId === priorInstanceId;
+
+        const { identifier, application } = await this.directory.registerNewInstance(
+            identityUrl,
+            reconnecting ? priorInstanceId : undefined,
+        );
+
+        const instanceUuid = reconnecting && priorInstanceUuid != null ? priorInstanceUuid : generateUUID();
+
         this.channelIdToAppIdentifier[channelId] = identifier;
         this.instanceIdToChannelId[identifier.instanceId] = channelId;
+        this.instanceUuidToIdentity[instanceUuid] = identifier;
 
         const response: BrowserTypes.WebConnectionProtocol5ValidateAppIdentitySuccessResponse = {
             type: 'WCP5ValidateAppIdentityResponse',
@@ -248,7 +293,7 @@ export class RootMessagePublisher implements IRootPublisher {
             },
             payload: {
                 ...identifier,
-                instanceUuid: generateUUID(),
+                instanceUuid,
                 implementationMetadata: await getImplementationMetadata(identifier, application),
             },
         };
@@ -258,6 +303,36 @@ export class RootMessagePublisher implements IRootPublisher {
         this.rootMessagingProvider.publish({ payload: response, channelIds: [channelId] });
 
         return identifier;
+    }
+
+    /**
+     * Publishes a WCP5ValidateAppIdentityFailedResponse to the connecting app, causing its getAgent()
+     * call to reject with AgentError.AccessDenied.
+     */
+    private publishFailedResponse(
+        validateMessage: BrowserTypes.WebConnectionProtocol4ValidateAppIdentity,
+        channelId: string,
+        message: string,
+    ): void {
+        const response: BrowserTypes.WebConnectionProtocol5ValidateAppIdentityFailedResponse = {
+            type: 'WCP5ValidateAppIdentityFailedResponse',
+            meta: {
+                connectionAttemptUuid: validateMessage.meta.connectionAttemptUuid,
+                timestamp: getTimestamp(),
+            },
+            payload: { message },
+        };
+
+        this.rootMessagingProvider.publish({ payload: response, channelIds: [channelId] });
+    }
+
+    /**
+     * Removes channel and identity mappings for a disconnected instance (e.g. after a WCP6Goodbye).
+     * The instanceUuid mapping is retained so the app can reconnect and reclaim its instanceId.
+     */
+    private forgetInstance(source: FullyQualifiedAppIdentifier, channelId: string): void {
+        delete this.channelIdToAppIdentifier[channelId];
+        delete this.instanceIdToChannelId[source.instanceId];
     }
 
     private connectionAttemptUuidCallbacks: Partial<Record<string, (identity: FullyQualifiedAppIdentifier) => void>> =


### PR DESCRIPTION
Brings the getAgent()/Desktop Agent handshake in line with the FDC3 Web Connection Protocol (WCP1-WCP6):

- Handle WCP2LoadUrl: load the agent URL into a hidden iframe and restart the handshake against it (isWCPLoadUrl predicate, ProxyUrl agent type).
- Handle WCP5 failure end-to-end: reject getAgent() with AccessDenied on a WCP5ValidateAppIdentityFailedResponse (was an indefinite hang) and have the root send that response instead of going silent (isWCPFailedResponse).
- Persist DesktopAgentDetails to SessionStorage and reconnect: read prior details, limit discovery to the previous mechanism, pass instanceId/ instanceUuid in WCP4 and reissue the same instanceId on the root.
- Channel selector / intent resolver plumbing: WCP1Hello carries the channelSelector/intentResolver flags and the proxy injects UI iframes when the handshake supplies URLs.
- Validate app identity origins: identityUrl, actualUrl and the WCP1Hello origin must match before identity is issued.
- Failover: restart the handshake against a returned WindowProxy and reject unsupported results with InvalidFailover.
- Clean up channel mappings on WCP6Goodbye.

Adds unit and integration coverage for the new behaviours.