### PR TITLE
fix: respect intent displayName in app resolver

### DIFF
--- a/projects/fdc3-web/src/agent/desktop-agent-proxy.ts
+++ b/projects/fdc3-web/src/agent/desktop-agent-proxy.ts
@@ -524,13 +524,15 @@ export class DesktopAgentProxy extends MessagingBase implements DesktopAgentNext
 }
 
 /**
- * Converts displayName property from string | undefined to string
+ * Maps an AppIntent returned in a response message (defined in BrowserTypes) to the AppIntent type defined in the
+ * FDC3 spec. The intent displayName is left untouched - it is undefined when the app directory does not supply one,
+ * allowing consumers to distinguish a directory-provided displayName from its absence.
  * @param appIntent is AppIntent returned in response message, defined in BrowserTypes
  * @returns AppIntent object of type defined in FDC3 spec
  */
 function mapMessageIntent(appIntent: BrowserTypes.AppIntent): AppIntent {
     return {
         ...appIntent,
-        intent: { ...appIntent.intent, displayName: appIntent.intent.displayName ?? appIntent.intent.name },
+        intent: { ...appIntent.intent },
     };
 }

--- a/projects/fdc3-web/src/app-directory/directory.spec.ts
+++ b/projects/fdc3-web/src/app-directory/directory.spec.ts
@@ -312,7 +312,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
                             screenshots: undefined,
                         },
                     ],
-                    intent: { name: 'StartChat', displayName: 'StartChat' },
+                    intent: { name: 'StartChat', displayName: undefined },
                 },
             };
 
@@ -505,7 +505,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
                                 screenshots: undefined,
                             },
                         ],
-                        intent: { name: 'StartChat', displayName: 'StartChat' },
+                        intent: { name: 'StartChat', displayName: undefined },
                     },
                     {
                         apps: [
@@ -520,7 +520,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
                                 screenshots: undefined,
                             },
                         ],
-                        intent: { name: 'StartEmail', displayName: 'StartEmail' },
+                        intent: { name: 'StartEmail', displayName: undefined },
                     },
                 ],
             };
@@ -611,7 +611,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
                         version: undefined,
                     },
                 ],
-                intent: { name: 'notAKnownIntent', displayName: 'notAKnownIntent' },
+                intent: { name: 'notAKnownIntent', displayName: undefined },
             });
         });
 
@@ -883,7 +883,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
                             version: undefined,
                         },
                     ],
-                    intent: { name: 'StartChat', displayName: 'StartChat' },
+                    intent: { name: 'StartChat', displayName: undefined },
                 },
                 {
                     apps: [
@@ -898,7 +898,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
                             version: undefined,
                         },
                     ],
-                    intent: { name: 'StartEmail', displayName: 'StartEmail' },
+                    intent: { name: 'StartEmail', displayName: undefined },
                 },
             ];
 
@@ -964,7 +964,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
                         version: undefined,
                     },
                 ],
-                intent: { displayName: 'StartChat', name: 'StartChat' },
+                intent: { displayName: undefined, name: 'StartChat' },
             });
         });
 
@@ -1002,7 +1002,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
                         version: undefined,
                     },
                 ],
-                intent: { displayName: 'StartChat', name: 'StartChat' },
+                intent: { displayName: undefined, name: 'StartChat' },
             });
         });
 
@@ -1062,7 +1062,7 @@ describe(`${AppDirectory.name} (directory)`, () => {
                     },
                 ],
                 intent: {
-                    displayName: 'StartChat',
+                    displayName: undefined,
                     name: 'StartChat',
                 },
             });
@@ -1076,14 +1076,14 @@ describe(`${AppDirectory.name} (directory)`, () => {
             expect(result.intent).toEqual({ name: 'ViewChart', displayName: 'View Chart' });
         });
 
-        it('should fall back to intent name as displayName when no app defines a displayName', async () => {
+        it('should leave displayName undefined when no app defines a displayName', async () => {
             const instance = createInstance([mockedAppDirectoryUrl]);
 
             await registerApp(instance, mockedApplicationOne, 'StartChat', [contact]);
 
             const result = await instance.getAppIntent('StartChat');
 
-            expect(result.intent).toEqual({ name: 'StartChat', displayName: 'StartChat' });
+            expect(result.intent).toEqual({ name: 'StartChat', displayName: undefined });
         });
     });
 

--- a/projects/fdc3-web/src/app-directory/directory.ts
+++ b/projects/fdc3-web/src/app-directory/directory.ts
@@ -507,7 +507,12 @@ export class AppDirectory {
         };
     }
 
-    private getIntentDisplayName(intent: Intent, apps: AppDirectoryApplication[]): string {
+    /**
+     * Returns the displayName supplied for the given intent in the app directory, or undefined if none is provided.
+     * We deliberately do not fall back to the raw intent name here so that consumers (e.g. the app resolver) can
+     * distinguish between a directory-provided displayName and the absence of one.
+     */
+    private getIntentDisplayName(intent: Intent, apps: AppDirectoryApplication[]): string | undefined {
         for (const app of apps) {
             const displayName = app.interop?.intents?.listensFor?.[intent]?.displayName;
             if (displayName != null) {
@@ -515,7 +520,7 @@ export class AppDirectory {
             }
         }
 
-        return intent;
+        return undefined;
     }
 
     /**

--- a/projects/ui-provider/src/app-resolver.component.spec.ts
+++ b/projects/ui-provider/src/app-resolver.component.spec.ts
@@ -17,7 +17,7 @@ import {
 } from '@morgan-stanley/fdc3-web';
 import { IMocked, Mock, setupFunction } from '@morgan-stanley/ts-mocking-bird';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { AppResolverComponent } from './app-resolver.component.js';
+import { AppResolverComponent, resolveDisplayName } from './app-resolver.component.js';
 
 const mockedTargetAppId = `mocked-target-app-id`;
 const mockedTargetInstanceId = `mocked-target-instance-id`;
@@ -175,7 +175,11 @@ describe(`${AppResolverComponent.name} (app-resolver.component)`, () => {
 
                             await wait();
 
-                            expect(instance.forIntentPopupState).toEqual({ name: 'StartEmail', ...expectedApps });
+                            expect(instance.forIntentPopupState).toEqual({
+                                name: 'StartEmail',
+                                displayName: 'StartEmail',
+                                ...expectedApps,
+                            });
                             expect(mockDocument.querySelector('body')?.querySelector('ms-app-resolver')).toBeDefined();
                         } else {
                             // expecting a single app to be returned immediately
@@ -380,8 +384,13 @@ describe(`${AppResolverComponent.name} (app-resolver.component)`, () => {
 
                             await wait();
 
-                            const intentLookup = expectedApps.reduce<Record<string, ExpectedApps>>(
-                                (lookup, { intent, apps }) => ({ ...lookup, [intent]: apps }),
+                            const intentLookup = expectedApps.reduce<
+                                Record<string, ExpectedApps & { displayName?: string }>
+                            >(
+                                (lookup, { intent, apps }) => ({
+                                    ...lookup,
+                                    [intent]: { displayName: intent, ...apps },
+                                }),
                                 {},
                             );
 
@@ -673,6 +682,89 @@ describe(`${AppResolverComponent.name} (app-resolver.component)`, () => {
         }
     });
 
+    describe('intent displayName', () => {
+        function shadowRoot(): ShadowRoot | null | undefined {
+            return mockDocument.querySelector('body')?.querySelector('ms-app-resolver')?.shadowRoot;
+        }
+
+        function intentPayload(name: string, displayName: string | undefined): ResolveForIntentPayload {
+            return {
+                context: { type: 'contact' },
+                intent: name,
+                appManifests: {},
+                appIntent: { intent: { name, displayName }, apps: [create(1), create(2)] },
+            };
+        }
+
+        function contextPayload(name: string, displayName: string | undefined): ResolveForContextPayload {
+            return {
+                context: { type: 'contact' },
+                appManifests: {},
+                appIntents: [{ intent: { name, displayName }, apps: [create(1), create(2)] }],
+            };
+        }
+
+        it('should show the directory displayName as the intent popup title when one is provided', async () => {
+            const instance = createInstance();
+
+            instance.resolveAppForIntent(intentPayload('ViewChart', 'Display A Chart'));
+
+            await wait();
+
+            expect(shadowRoot()?.querySelector('.ms-app-resolver-popup-title')?.textContent?.trim()).toBe(
+                'Display A Chart',
+            );
+        });
+
+        it('should show the humanized intent name as the intent popup title when no displayName is provided', async () => {
+            const instance = createInstance();
+
+            instance.resolveAppForIntent(intentPayload('ViewChart', undefined));
+
+            await wait();
+
+            expect(shadowRoot()?.querySelector('.ms-app-resolver-popup-title')?.textContent?.trim()).toBe('View Chart');
+        });
+
+        it('should show the directory displayName as the context popup intent title when one is provided', async () => {
+            const instance = createInstance();
+
+            instance.resolveAppForContext(contextPayload('ViewChart', 'Display A Chart'));
+
+            await wait();
+
+            expect(shadowRoot()?.querySelector('.ms-app-resolver-popup-intent-title')?.textContent?.trim()).toBe(
+                'Display A Chart',
+            );
+        });
+
+        it('should show the humanized intent name as the context popup intent title when no displayName is provided', async () => {
+            const instance = createInstance();
+
+            instance.resolveAppForContext(contextPayload('ViewChart', undefined));
+
+            await wait();
+
+            expect(shadowRoot()?.querySelector('.ms-app-resolver-popup-intent-title')?.textContent?.trim()).toBe(
+                'View Chart',
+            );
+        });
+
+        it('should keep the raw intent name as the data-intent attribute regardless of displayName', async () => {
+            const instance = createInstance();
+
+            instance.resolveAppForContext(contextPayload('ViewChart', 'Display A Chart'));
+
+            await wait();
+
+            expect(
+                shadowRoot()
+                    ?.querySelector('[automation-id="fdc3-app-resolver_intent-group"]')
+                    ?.getAttribute('data-intent'),
+            ).toBe('ViewChart');
+        });
+    });
+
     function createIntentPayload(
         appsInPayload: boolean,
         apps: AppIdentifier[],
@@ -708,4 +800,27 @@ describe(`${AppResolverComponent.name} (app-resolver.component)`, () => {
             setTimeout(() => resolve(), delay);
         });
     }
+});
+
+describe('resolveDisplayName', () => {
+    it('should return the displayName when one is provided', () => {
+        expect(resolveDisplayName({ name: 'ViewChart', displayName: 'Display A Chart' })).toBe('Display A Chart');
+    });
+
+    const humanizedCases: { name: string; expected: string }[] = [
+        { name: 'ViewChart', expected: 'View Chart' },
+        { name: 'StartChat', expected: 'Start Chat' },
+        { name: 'view-contact', expected: 'View Contact' },
+        { name: 'view_contact', expected: 'View Contact' },
+        { name: 'ViewFXChart', expected: 'View FX Chart' },
+        { name: 'startChat2', expected: 'Start Chat 2' },
+        { name: 'SendEmail', expected: 'Send Email' },
+        { name: 'lowercase', expected: 'Lowercase' },
+    ];
+
+    humanizedCases.forEach(({ name, expected }) => {
+        it(`should humanize "${name}" to "${expected}" when no displayName is provided`, () => {
+            expect(resolveDisplayName({ name, displayName: undefined })).toBe(expected);
+        });
+    });
 });

--- a/projects/ui-provider/src/app-resolver.component.ts
+++ b/projects/ui-provider/src/app-resolver.component.ts
@@ -519,7 +519,7 @@ export function resolveDisplayName({ name, displayName }: { name: string; displa
         displayName ??
         name
             .replace(/[-_]+/g, ' ')
-            .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+            .replace(/([A-Z])(?=[A-Z][a-z])/g, '$1 ')
             .replace(/([a-z\d])([A-Z])/g, '$1 $2')
             .replace(/([A-Za-z])(\d)/g, '$1 $2')
             .replace(/\s+/g, ' ')

--- a/projects/ui-provider/src/app-resolver.component.ts
+++ b/projects/ui-provider/src/app-resolver.component.ts
@@ -203,7 +203,12 @@ export class AppResolverComponent extends LitElement implements IAppResolver {
             return Promise.reject(ResolveError.NoAppsFound);
         }
 
-        this._forIntentPopupState = { name: appIntent.intent.name, activeInstances, inactiveApps };
+        this._forIntentPopupState = {
+            name: appIntent.intent.name,
+            displayName: appIntent.intent.displayName,
+            activeInstances,
+            inactiveApps,
+        };
 
         this.togglePopup();
         return (await this.getSelectedApp()).app;
@@ -231,19 +236,23 @@ export class AppResolverComponent extends LitElement implements IAppResolver {
                     return { ...appIntent, apps };
                 })
                 .filter(appIntent => appIntent.apps.length > 0)
-                .reduce<Record<string, { activeInstances: AppMetadata[]; inactiveApps: AppMetadata[] }>>(
-                    (lookup, appIntent) => {
-                        //active app instances that can handle given intent
-                        const activeInstances = appIntent.apps.filter(filterActiveApps);
-                        //apps that can handle given intent (excluding singletons which already have an active instance)
-                        const inactiveApps = appIntent.apps.filter(app =>
-                            filterInactiveApps(app, globalActiveInstances, payload.appManifests),
-                        );
+                .reduce<ContextPopupState>((lookup, appIntent) => {
+                    //active app instances that can handle given intent
+                    const activeInstances = appIntent.apps.filter(filterActiveApps);
+                    //apps that can handle given intent (excluding singletons which already have an active instance)
+                    const inactiveApps = appIntent.apps.filter(app =>
+                        filterInactiveApps(app, globalActiveInstances, payload.appManifests),
+                    );
 
-                        return { ...lookup, [appIntent.intent.name]: { activeInstances, inactiveApps } };
-                    },
-                    {},
-                );
+                    return {
+                        ...lookup,
+                        [appIntent.intent.name]: {
+                            displayName: appIntent.intent.displayName,
+                            activeInstances,
+                            inactiveApps,
+                        },
+                    };
+                }, {});
 
         const appCandidates = Object.entries(intentLookup).flatMap(([intent, apps]) =>
             [...apps.activeInstances, ...apps.inactiveApps].map(app => ({ intent, app })),
@@ -358,7 +367,7 @@ export class AppResolverComponent extends LitElement implements IAppResolver {
                 <h1 class="ms-app-resolver-popup-title">
                     ${when(this.forIntentPopupState != null || this.forContextPopupState != null, () => {
                         if (this.forIntentPopupState != null) {
-                            return this.forIntentPopupState?.name;
+                            return resolveDisplayName(this.forIntentPopupState);
                         }
                         return this.passedContext?.name ?? 'Resolve For Context';
                     })}
@@ -442,7 +451,9 @@ function renderForContextPopup(component: AppResolverComponent): TemplateResult 
                         type="button"
                         @click=${() => component.toggleIntentContainer(intent[0])}
                     >
-                        <h2 class="ms-app-resolver-popup-intent-title">${intent[0]}</h2>
+                        <h2 class="ms-app-resolver-popup-intent-title">
+                            ${resolveDisplayName({ name: intent[0], displayName: intent[1].displayName })}
+                        </h2>
                         <div class="ms-app-resolver-popup-intent-title-chevron" id="${intent[0]}-chevron">
                             <svg height="15" width="15">
                                 <path d="M0 8.5 L7.5 0.75 L15 8.5" style="fill:none;stroke:black;stroke-width:1.5" />
@@ -494,4 +505,25 @@ function renderAppIcon(icon?: Icon): TemplateResult {
         <circle cx="10" cy="10" r="5" stroke="black" stroke-width="0.1" fill="black" />
         o
     </svg>`;
+}
+
+/**
+ * Resolves the title to display for an intent. Uses the displayName supplied by the app directory when present,
+ * otherwise falls back to a best-effort human readable version of the intent name: splits camelCase / PascalCase
+ * boundaries (keeping acronym runs together), treats '-' and '_' as word separators, separates trailing digits and
+ * capitalises the first letter of each word.
+ * e.g. "ViewChart" -> "View Chart", "view-contact" -> "View Contact", "ViewFXChart" -> "View FX Chart".
+ */
+export function resolveDisplayName({ name, displayName }: { name: string; displayName?: string }): string {
+    return (
+        displayName ??
+        name
+            .replace(/[-_]+/g, ' ')
+            .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+            .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+            .replace(/([A-Za-z])(\d)/g, '$1 $2')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .replace(/\b\w/g, char => char.toUpperCase())
+    );
 }

--- a/projects/ui-provider/src/contracts.ts
+++ b/projects/ui-provider/src/contracts.ts
@@ -10,5 +10,19 @@
 
 import { AppMetadata } from '@finos/fdc3';
 
-export type IntentPopupState = { name: string; activeInstances: AppMetadata[]; inactiveApps: AppMetadata[] };
-export type ContextPopupState = Record<string, { activeInstances: AppMetadata[]; inactiveApps: AppMetadata[] }>;
+export type IntentPopupState = {
+    name: string;
+    /** Unaltered displayName supplied by the app directory for this intent, or undefined if none was provided. */
+    displayName?: string;
+    activeInstances: AppMetadata[];
+    inactiveApps: AppMetadata[];
+};
+export type ContextPopupState = Record<
+    string,
+    {
+        /** Unaltered displayName supplied by the app directory for this intent, or undefined if none was provided. */
+        displayName?: string;
+        activeInstances: AppMetadata[];
+        inactiveApps: AppMetadata[];
+    }
+>;


### PR DESCRIPTION
Use the displayName supplied for an intent in the app directory when rendering the app resolver. When no displayName is provided, fall back to a best-effort humanized version of the intent name (e.g. "ViewChart" -> "View Chart"), with the humanization done in the UI resolver.

- directory.getIntentDisplayName returns undefined when no app supplies a displayName, so its absence is distinguishable downstream
- desktop-agent-proxy.mapMessageIntent no longer forces displayName to the intent name, passing the directory value through untouched
- IntentPopupState / ContextPopupState carry the unaltered displayName
- resolveDisplayName takes the popup state and returns the displayName or a human readable version of the intent name, keeping the raw intent name for keys, data-intent and selection