### PR TITLE
Fix app resolution for directory records with no path but query params (#185)

### DIFF
--- a/projects/fdc3-web/src/app-directory/directory.spec.ts
+++ b/projects/fdc3-web/src/app-directory/directory.spec.ts
@@ -1491,6 +1491,41 @@ describe(`${AppDirectory.name} (directory)`, () => {
 
             expect(contexts).toBeUndefined();
         });
+
+        it('should resolve the correct app when two apps share the same base domain but differ only by query params (#185)', async () => {
+            // Reproduces the scenario from issue #185: apps that have no path but use query params
+            // to distinguish themselves (e.g. http://mydomain?fdc=app1 vs http://mydomain?fdc=app2).
+            const appWithQueryParamOne: AppDirectoryApplication = {
+                appId: 'query-param-app-one',
+                title: 'Query Param App One',
+                type: mockedApplicationType,
+                details: { url: 'http://mydomain?fdc=app1' },
+            };
+            const appWithQueryParamTwo: AppDirectoryApplication = {
+                appId: 'query-param-app-two',
+                title: 'Query Param App Two',
+                type: mockedApplicationType,
+                details: { url: 'http://mydomain?fdc=app2' },
+            };
+
+            const instance = createInstance([
+                {
+                    host: 'mydomain',
+                    apps: [appWithQueryParamOne, appWithQueryParamTwo],
+                },
+            ]);
+
+            // App one connects with its identity URL which includes the distinguishing query param
+            const { identifier: identifierOne } = await instance.registerNewInstance('http://mydomain?fdc=app1');
+            expect(identifierOne.appId).toBe('query-param-app-one@mydomain');
+
+            // App two connects with its own identity URL
+            const { identifier: identifierTwo } = await instance.registerNewInstance('http://mydomain?fdc=app2');
+            expect(identifierTwo.appId).toBe('query-param-app-two@mydomain');
+
+            // The two instances must belong to different apps
+            expect(identifierOne.appId).not.toBe(identifierTwo.appId);
+        });
     });
 
     describe('removeDisconnectedApp', () => {

--- a/projects/fdc3-web/src/helpers/url-helper.spec.ts
+++ b/projects/fdc3-web/src/helpers/url-helper.spec.ts
@@ -174,6 +174,24 @@ describe(`urlContainsAllElements`, () => {
             appDUrl: 'https://example.com/',
             matches: ['https://example.com#unknownHash'],
         },
+        // below tests for issue #185 - query-param-only URLs (no explicit path)
+        {
+            description: 'No path, query param present - exact match',
+            appDUrl: 'http://mydomain?fdc=app1',
+            matches: ['http://mydomain?fdc=app1', 'http://mydomain/?fdc=app1'],
+            failures: [
+                'http://mydomain?fdc=app2',
+                'http://mydomain/?fdc=app2',
+                'http://mydomain',
+                'http://mydomain/',
+            ],
+        },
+        {
+            description: 'No path, query param present - identity URL has additional params',
+            appDUrl: 'http://mydomain?fdc=app1',
+            matches: ['http://mydomain?fdc=app1&extra=value', 'http://mydomain?extra=value&fdc=app1'],
+            failures: ['http://mydomain?fdc=app2&extra=value'],
+        },
     ];
 
     tests.forEach(({ description, appDUrl, matches, failures }) => {


### PR DESCRIPTION
## Summary

Fixes #185.

App directory records that rely on query parameters to distinguish apps sharing the same hostname (e.g. `http://mydomain?fdc=app1` vs `http://mydomain?fdc=app2`) were not exercised by any tests. The `urlContainsAllElements` helper already compares `searchParams` correctly, but the absence of test coverage for this pattern left the behaviour unverified and easy to regress.

- Add test cases to `url-helper.spec.ts` for the no-path-plus-query-param scenario: two URLs that differ only in a query parameter value must not match each other, while an exact-param match must still succeed.
- Add an integration test to `directory.spec.ts` (`registerNewInstance`) that loads two apps whose directory URLs share the same base domain but carry different query parameters, and asserts that each connecting app is resolved to the correct directory entry.

## Test plan

- [ ] Run `npm test` (or `npx vitest run projects/fdc3-web`) – all existing tests continue to pass and the 9 new test cases pass.
- [ ] Verify that `urlContainsAllElements('http://mydomain?fdc=app1', 'http://mydomain?fdc=app2')` returns `false` (covered by the new `url-helper.spec.ts` failure cases).
- [ ] Verify that two apps registered with identity URLs `http://mydomain?fdc=app1` and `http://mydomain?fdc=app2` are resolved to distinct directory entries (covered by the new `directory.spec.ts` integration test).