### PR TITLE
fix(app-directory): remove app instance when launched window closes (#187)

### DIFF
--- a/projects/fdc3-web/src/agent/desktop-agent.spec.ts
+++ b/projects/fdc3-web/src/agent/desktop-agent.spec.ts
@@ -2398,6 +2398,86 @@ describe(`${DesktopAgentImpl.name} (desktop-agent)`, () => {
                         .withParametersEqualTo(expectedMessage, source),
                 ).wasCalledOnce();
             });
+
+            it(`should pass an onWindowClosed callback to the open strategy and remove the app instance when invoked`, async () => {
+                createInstance([mockOpenStrategy.mock]);
+
+                const openMessage: BrowserTypes.OpenRequest = {
+                    meta: {
+                        requestUuid: mockedRequestUuid,
+                        timestamp: currentDate,
+                        source: { appId: mockedTargetAppId, instanceId: mockedTargetInstanceId },
+                    },
+                    payload: {
+                        app: { appId: mockedTargetAppId },
+                    },
+                    type: 'openRequest',
+                };
+
+                await postRequestMessage(openMessage, source);
+
+                // Verify that the strategy received an onWindowClosed callback
+                const openParams = mockOpenStrategy.functionCallLookup['open']?.[0][0];
+                expect(openParams?.onWindowClosed).toBeDefined();
+
+                // Invoking onWindowClosed should remove the opened app instance from the directory
+                openParams?.onWindowClosed?.();
+
+                const openedAppIdentifier = { appId: mockedTargetAppId, instanceId: mockedGeneratedUuid };
+
+                expect(
+                    mockAppDirectory
+                        .withFunction('removeDisconnectedApp')
+                        .withParametersEqualTo(openedAppIdentifier),
+                ).wasCalledOnce();
+
+                expect(mockChannelHandler.withFunction('cleanupDisconnectedProxy')).wasCalledOnce();
+            });
+
+            it(`should not remove the app instance when onWindowClosed is called before the child window has connected`, async () => {
+                // Simulate strategy whose open() resolves before awaitAppIdentity completes, so
+                // onWindowClosed fires while openedAppIdentifier is still undefined.
+                const neverResolvingStrategy = Mock.create<IOpenApplicationStrategy>().setup(
+                    setupProperty('manifestKey', 'mock-application'),
+                    setupFunction('canOpen', () => Promise.resolve(true)),
+                    setupFunction('open', () => Promise.resolve(`mock-connection-attempt-uuid`)),
+                );
+
+                mockRootPublisher.setupFunction(
+                    'awaitAppIdentity',
+                    () => new Promise(() => { /* never resolves */ }),
+                );
+
+                createInstance([neverResolvingStrategy.mock]);
+
+                const openMessage: BrowserTypes.OpenRequest = {
+                    meta: {
+                        requestUuid: mockedRequestUuid,
+                        timestamp: currentDate,
+                        source: { appId: mockedTargetAppId, instanceId: mockedTargetInstanceId },
+                    },
+                    payload: {
+                        app: { appId: mockedTargetAppId },
+                    },
+                    type: 'openRequest',
+                };
+
+                // Fire and forget – openAppWithStrategy will stall at awaitAppIdentity
+                postRequestMessage(openMessage, source);
+
+                // Let microtasks run so strategy.open() is called
+                await wait();
+
+                const openParams = neverResolvingStrategy.functionCallLookup['open']?.[0][0];
+                expect(openParams?.onWindowClosed).toBeDefined();
+
+                // Call onWindowClosed before the app has connected
+                openParams?.onWindowClosed?.();
+
+                // No cleanup should have happened because openedAppIdentifier is not yet set
+                expect(mockAppDirectory.withFunction('removeDisconnectedApp')).wasNotCalled();
+                expect(mockChannelHandler.withFunction('cleanupDisconnectedProxy')).wasNotCalled();
+            });
         });
 
         describe(`getUserChannelsRequest`, () => {

--- a/projects/fdc3-web/src/agent/desktop-agent.ts
+++ b/projects/fdc3-web/src/agent/desktop-agent.ts
@@ -1021,6 +1021,21 @@ export class DesktopAgentImpl extends DesktopAgentProxy implements DesktopAgentN
                 resolveAppIdentity = resolve;
             });
 
+            // Capture the app identifier once the child window has connected, then use it in the
+            // window-closed callback below so that we can remove the correct instance.
+            let openedAppIdentifier: FullyQualifiedAppIdentifier | undefined;
+
+            const onWindowClosed = (): void => {
+                if (openedAppIdentifier != null) {
+                    this.connectionLog(
+                        'Child window closed – removing app instance',
+                        LogLevel.INFO,
+                        openedAppIdentifier,
+                    );
+                    this.handleProxyDisconnect(openedAppIdentifier);
+                }
+            };
+
             const newAppConnectionAttemptUuid = await strategy
                 .open({
                     appDirectoryRecord: noManifests,
@@ -1030,6 +1045,7 @@ export class DesktopAgentImpl extends DesktopAgentProxy implements DesktopAgentN
                     ),
                     context,
                     appReadyPromise,
+                    onWindowClosed,
                 })
                 .catch(err => {
                     openError = err;
@@ -1066,6 +1082,9 @@ export class DesktopAgentImpl extends DesktopAgentProxy implements DesktopAgentN
                 newAppConnectionAttemptUuid,
                 application,
             );
+
+            // Store the identifier so that the onWindowClosed callback can reference it.
+            openedAppIdentifier = appIdentifier;
 
             if (resolveAppIdentity != null) {
                 resolveAppIdentity(appIdentifier);

--- a/projects/fdc3-web/src/agent/fallback-open-strategy.spec.ts
+++ b/projects/fdc3-web/src/agent/fallback-open-strategy.spec.ts
@@ -18,9 +18,9 @@ import {
     setupFunction,
     setupProperty,
 } from '@morgan-stanley/ts-mocking-bird';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppDirectoryApplicationType } from '../app-directory.contracts.js';
-import { ApplicationStrategyParams, DesktopAgentNext } from '../contracts.js';
+import { ApplicationStrategyParams, DesktopAgentNext, OpenApplicationStrategyResolverParams } from '../contracts.js';
 import * as helpersImport from '../helpers/index.js';
 import { FallbackOpenStrategy } from './fallback-open-strategy.js';
 
@@ -200,6 +200,70 @@ describe(`${FallbackOpenStrategy.name} (fallback-open-strategy)`, () => {
             (mockWindow.functionCallLookup.addEventListener?.[0][1] as EventListener)?.(mockMessageEvent);
 
             await expect(identityPromise).resolves.toStrictEqual('mock-connection-attempt-uuid');
+        });
+
+        it(`should invoke onWindowClosed callback when the opened popup window is detected as closed`, async () => {
+            vi.useFakeTimers();
+
+            const instance = createInstance(mockWindow.mock);
+
+            const onWindowClosed = vi.fn();
+
+            // Simulate child window starting open
+            mockChildWindow.setup(setupProperty('closed', false));
+
+            const params: OpenApplicationStrategyResolverParams = {
+                appDirectoryRecord: mockedApplication,
+                agent: mockDesktopAgent.mock,
+                appReadyPromise: new Promise(() => {
+                    /* never resolves in this test */
+                }),
+                onWindowClosed,
+            };
+
+            // Start the open – the connection attempt promise will never resolve but that is fine
+            // for this test because we only care about the window-close side-effect.
+            instance.open(params);
+
+            // Window is still open – callback should not have been called yet
+            await vi.advanceTimersByTimeAsync(500);
+            expect(onWindowClosed).not.toHaveBeenCalled();
+
+            // Simulate the popup window being closed
+            mockChildWindow.setup(setupProperty('closed', true));
+
+            // Advance past the next poll interval
+            await vi.advanceTimersByTimeAsync(500);
+
+            expect(onWindowClosed).toHaveBeenCalledOnce();
+
+            // Advancing again should NOT trigger a second call (poll stopped after first fire)
+            await vi.advanceTimersByTimeAsync(1000);
+            expect(onWindowClosed).toHaveBeenCalledOnce();
+
+            vi.useRealTimers();
+        });
+
+        it(`should not invoke onWindowClosed if no callback is provided`, async () => {
+            vi.useFakeTimers();
+
+            // Simulate child window immediately closed – no callback is registered so there
+            // should be no error thrown.
+            mockChildWindow.setup(setupProperty('closed', true));
+
+            const instance = createInstance(mockWindow.mock);
+
+            const params: ApplicationStrategyParams = {
+                appDirectoryRecord: mockedApplication,
+                agent: mockDesktopAgent.mock,
+            };
+
+            // Should not throw even when the child window is already closed
+            instance.open(params);
+
+            await vi.advanceTimersByTimeAsync(1000);
+
+            vi.useRealTimers();
         });
     });
 });

--- a/projects/fdc3-web/src/agent/fallback-open-strategy.ts
+++ b/projects/fdc3-web/src/agent/fallback-open-strategy.ts
@@ -9,18 +9,24 @@
  * and limitations under the License. */
 
 import { OpenError } from '@finos/fdc3';
-import { ApplicationStrategyParams, IOpenApplicationStrategy } from '../contracts.js';
+import { IOpenApplicationStrategy, OpenApplicationStrategyResolverParams } from '../contracts.js';
 import { isWebAppDetails, subscribeToConnectionAttemptUuids } from '../helpers/index.js';
+
+/**
+ * Interval (ms) used to poll `window.closed` on the newly-opened popup.
+ * Kept short so that instance removal is perceived as near-instant.
+ */
+const WINDOW_CLOSED_POLL_INTERVAL_MS = 500;
 
 export class FallbackOpenStrategy implements IOpenApplicationStrategy {
     //window parameter is passed during testing
     constructor(private currentWindow: Window = window) {}
 
-    public async canOpen(params: ApplicationStrategyParams): Promise<boolean> {
+    public async canOpen(params: OpenApplicationStrategyResolverParams): Promise<boolean> {
         return params.appDirectoryRecord.type === 'web' && isWebAppDetails(params.appDirectoryRecord.details);
     }
 
-    public async open(params: ApplicationStrategyParams): Promise<string> {
+    public async open(params: OpenApplicationStrategyResolverParams): Promise<string> {
         if (!isWebAppDetails(params.appDirectoryRecord.details)) {
             //this should not occur since canOpen() will have already checked this
             return Promise.reject(OpenError.ErrorOnLaunch);
@@ -29,6 +35,10 @@ export class FallbackOpenStrategy implements IOpenApplicationStrategy {
         if (newWindow == null) {
             //new window could not be opened
             return Promise.reject(OpenError.ErrorOnLaunch);
+        }
+
+        if (params.onWindowClosed != null) {
+            this.monitorWindowClosed(newWindow, params.onWindowClosed);
         }
 
         return new Promise(resolve => {
@@ -42,5 +52,21 @@ export class FallbackOpenStrategy implements IOpenApplicationStrategy {
                 },
             );
         });
+    }
+
+    /**
+     * Polls `childWindow.closed` at a fixed interval. As soon as the window is detected as closed
+     * the `onClosed` callback is invoked and polling stops.
+     *
+     * We poll from the *root* window context so that the check survives even when the child
+     * window's own JavaScript execution is torn down during unload.
+     */
+    private monitorWindowClosed(childWindow: Window, onClosed: () => void): void {
+        const poll = setInterval(() => {
+            if (childWindow.closed) {
+                clearInterval(poll);
+                onClosed();
+            }
+        }, WINDOW_CLOSED_POLL_INTERVAL_MS);
     }
 }

--- a/projects/fdc3-web/src/contracts.ts
+++ b/projects/fdc3-web/src/contracts.ts
@@ -355,6 +355,12 @@ export type ApplicationStrategyParams = {
 
 export type OpenApplicationStrategyResolverParams = ApplicationStrategyParams & {
     appReadyPromise: Promise<FullyQualifiedAppIdentifier>;
+    /**
+     * Optional callback invoked by the strategy when the opened window or frame is detected to have
+     * closed. The desktop agent uses this to eagerly remove the associated app instance from the
+     * directory rather than waiting for the heartbeat to time out.
+     */
+    onWindowClosed?: () => void;
 };
 
 export type DesktopAgentStrategies = IOpenApplicationStrategy | ISelectApplicationStrategy;


### PR DESCRIPTION
## Problem

When `raiseIntent` (or `open`) launches a new window, closing that window does not remove the app instance from the root desktop agent's active instance list. On the next `raiseIntent` call the UI resolver shows the dead instance as available, leading to a broken intent resolution.

Fixes #187.

## Root cause

`FallbackOpenStrategy.open()` had no way to notify the desktop agent when the opened window closed. The instance was only removed when the heartbeat mechanism eventually timed out.

## Fix

- **`contracts.ts`**: add an optional `onWindowClosed?: () => void` callback to `OpenApplicationStrategyResolverParams`.
- **`fallback-open-strategy.ts`**: after opening the window, poll `childWindow.closed` at 500 ms intervals; invoke `onWindowClosed` as soon as closure is detected, then stop polling.
- **`desktop-agent.ts`**: wire the callback in `openAppWithStrategy` to call `handleProxyDisconnect(openedAppIdentifier)` so the instance is removed immediately when the window closes rather than waiting for the heartbeat timeout.

## Testing

- Added unit tests in `fallback-open-strategy.spec.ts` verifying that the callback fires when the mock window's `closed` flag becomes `true`, and does not fire while the window remains open.
- Added a test in `desktop-agent.spec.ts` verifying that `handleProxyDisconnect` is called with the correct identifier when `onWindowClosed` fires.