### PR TITLE
Implement INewInstanceStrategy and update for every new app instance handshake

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v3.29.5
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -55,7 +55,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -68,6 +68,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v3.29.5
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{matrix.language}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 0.16.0 (2026-07-22)
+
+### 🚀 Features
+
+- **fdc3-web:** Add `INewInstanceStrategy`, notified whenever a new app instance completes its connection handshake and is assigned an `instanceId`. Unlike `IOpenApplicationStrategy`, this fires for every new instance regardless of how its window was created (via an `IOpenApplicationStrategy`, a plain `window.open()` call, an iframe, etc.), so it can be used to track or manage app windows that were not opened by the desktop agent itself. ([a3642b6](https://github.com/Roaders/fdc3-web/commit/a3642b6))
+
+```js
+const customNewInstanceStrategy = {
+  onNewInstance: (params) => {
+    // params.fullyQualifiedAppIdentifier contains the appId/instanceId of the new app instance
+    // params.window is the window the app instance connected from, if known
+    myWindowRegistry.track(params.fullyQualifiedAppIdentifier, params.window);
+  }
+};
+
+const agent = await getAgent({
+  failover: () =>
+    new DesktopAgentFactory().createRoot({
+      applicationStrategies: [customNewInstanceStrategy],
+    }),
+});
+```
+
 ## 0.15.0 (2026-06-29)
 
 ### 🚀 Features

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Configure singleton behavior via the `hostManifests` property in your app direct
 
 ## Custom Application Strategies
 
-Application strategies control how apps are opened and selected. There are two types of strategies:
+Application strategies control how apps are opened, selected, and tracked. There are three types of strategies:
 
 ### Open Application Strategy
 
@@ -216,18 +216,36 @@ const customSelectStrategy = {
 };
 ```
 
+### New Instance Strategy
+
+Notified whenever a new app instance completes its connection handshake and is assigned an `instanceId`. Unlike
+`IOpenApplicationStrategy`, this is called for every new instance regardless of how its window was created (via an
+`IOpenApplicationStrategy`, a plain `window.open()` call, an iframe, etc.), so it is useful for strategies that need
+to track or manage all app windows rather than just the ones they opened themselves. Implement `INewInstanceStrategy`:
+
+```js
+const customNewInstanceStrategy = {
+  onNewInstance: (params) => {
+    // params.fullyQualifiedAppIdentifier contains the appId/instanceId of the new app instance
+    // params.window is the window the app instance connected from, if known
+    myWindowRegistry.track(params.fullyQualifiedAppIdentifier, params.window);
+  }
+};
+```
+
 Pass strategies when creating the root agent:
 
 ```js
 const agent = await getAgent({
   failover: () =>
     new DesktopAgentFactory().createRoot({
-      applicationStrategies: [customOpenStrategy, customSelectStrategy],
+      applicationStrategies: [customOpenStrategy, customSelectStrategy, customNewInstanceStrategy],
     }),
 });
 ```
 
-Strategies are evaluated in order. The first strategy where `canOpen()` or `canSelectApp()` returns `true` will be used.
+Strategies are evaluated in order. The first strategy where `canOpen()` or `canSelectApp()` returns `true` will be
+used. All `INewInstanceStrategy` strategies are notified for every new instance.
 
 ## Backoff Retry for App Directory Loading
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4584,9 +4584,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -4604,9 +4601,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -4624,9 +4618,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -4644,9 +4635,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -4664,9 +4652,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -4684,9 +4669,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2881,7 +2881,6 @@
         },
         "node_modules/@jridgewell/source-map": {
             "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
             "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
             "dev": true,
             "license": "MIT",
@@ -3997,8 +3996,7 @@
         },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "integrity": "sha1-a3kDLnYKCJnNQgRxC+7elyo6GF8=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5462,8 +5460,7 @@
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
-            "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+            "integrity": "sha1-qfagfysDyVyNOMRTah/ftSH/VbY=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5474,32 +5471,28 @@
         },
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-            "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+            "integrity": "sha1-/Moe7dscxOe27tT8eVbWgTshufs=",
             "dev": true,
             "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-            "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+            "integrity": "sha1-4KFhUiSLw42u523X4h8Vxe86sec=",
             "dev": true,
             "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-            "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+            "integrity": "sha1-giqbxgMWZTH31d+E5ntb+ZtyuWs=",
             "dev": true,
             "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
-            "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+            "integrity": "sha1-29kyVI5xGfS4p4d/1ajSDmNJCy0=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5511,16 +5504,14 @@
         },
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-            "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+            "integrity": "sha1-5VYQh1j0SKroTIUOWTzhig6zHgs=",
             "dev": true,
             "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
-            "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+            "integrity": "sha1-lindqcRDDqtUtZEFPW3G87oFA0g=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5533,8 +5524,7 @@
         },
         "node_modules/@webassemblyjs/ieee754": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
-            "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+            "integrity": "sha1-HF6qzh1gatosf9cEXqk1bFnuDbo=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5544,8 +5534,7 @@
         },
         "node_modules/@webassemblyjs/leb128": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
-            "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+            "integrity": "sha1-V8XD3rAQXQLOJfo/109OvJ/Qu7A=",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -5555,16 +5544,14 @@
         },
         "node_modules/@webassemblyjs/utf8": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-            "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+            "integrity": "sha1-kXog6T9xrVYClmwtaFrgxsIfYPE=",
             "dev": true,
             "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
-            "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+            "integrity": "sha1-rGaJ9QIhm1kZjd7ELc1JaxAE1Zc=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5581,8 +5568,7 @@
         },
         "node_modules/@webassemblyjs/wasm-gen": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
-            "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+            "integrity": "sha1-mR5/DAkMsLtiu6yIIHbj0hnalXA=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5596,8 +5582,7 @@
         },
         "node_modules/@webassemblyjs/wasm-opt": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
-            "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+            "integrity": "sha1-5vce18yuRngcIGAX08FMUO+oEGs=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5610,8 +5595,7 @@
         },
         "node_modules/@webassemblyjs/wasm-parser": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
-            "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+            "integrity": "sha1-s+E/GJNgXKeLUsaOVM9qhl+Qufs=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5626,8 +5610,7 @@
         },
         "node_modules/@webassemblyjs/wast-printer": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
-            "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+            "integrity": "sha1-O7PpY4qK5f2vlhDnoGtNn5qm/gc=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5638,16 +5621,14 @@
         },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
             "dev": true,
             "license": "BSD-3-Clause",
             "peer": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true
@@ -5725,7 +5706,6 @@
         },
         "node_modules/acorn-import-phases": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
             "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
             "dev": true,
             "license": "MIT",
@@ -5786,8 +5766,7 @@
         },
         "node_modules/ajv-formats": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "integrity": "sha1-bmaUAGWet0lzu/LjMycYCgmWtSA=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5805,7 +5784,6 @@
         },
         "node_modules/ajv-formats/node_modules/ajv": {
             "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
@@ -5823,8 +5801,7 @@
         },
         "node_modules/ajv-formats/node_modules/json-schema-traverse": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
             "dev": true,
             "license": "MIT",
             "peer": true
@@ -6543,8 +6520,7 @@
         },
         "node_modules/chrome-trace-event": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
-            "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+            "integrity": "sha1-Bb/9f/koRlCTMUcIyTvfqb0fD1s=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -6666,7 +6642,6 @@
         },
         "node_modules/commander": {
             "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
             "license": "MIT",
@@ -7191,9 +7166,8 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.24.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
-            "integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
+            "version": "5.24.2",
+            "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -7933,8 +7907,7 @@
         },
         "node_modules/events": {
             "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -9615,7 +9588,6 @@
         },
         "node_modules/jest-worker": {
             "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "license": "MIT",
@@ -9631,7 +9603,6 @@
         },
         "node_modules/jest-worker/node_modules/supports-color": {
             "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "license": "MIT",
@@ -9913,7 +9884,6 @@
         },
         "node_modules/loader-runner": {
             "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
             "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
             "dev": true,
             "license": "MIT",
@@ -10096,8 +10066,7 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
             "dev": true,
             "license": "MIT",
             "peer": true
@@ -10202,7 +10171,6 @@
         },
         "node_modules/minimizer-webpack-plugin": {
             "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
             "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
             "dev": true,
             "license": "MIT",
@@ -10333,8 +10301,7 @@
         },
         "node_modules/neo-async": {
             "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
             "dev": true,
             "license": "MIT",
             "peer": true
@@ -12065,7 +12032,6 @@
         },
         "node_modules/schema-utils": {
             "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
             "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
             "dev": true,
             "license": "MIT",
@@ -12086,7 +12052,6 @@
         },
         "node_modules/schema-utils/node_modules/ajv": {
             "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
@@ -12104,8 +12069,7 @@
         },
         "node_modules/schema-utils/node_modules/ajv-keywords": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+            "integrity": "sha1-adTThaRzPNvqtElkoRcKiPh/DhY=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -12118,8 +12082,7 @@
         },
         "node_modules/schema-utils/node_modules/json-schema-traverse": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
             "dev": true,
             "license": "MIT",
             "peer": true
@@ -12748,7 +12711,6 @@
         },
         "node_modules/tapable": {
             "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
             "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
             "dev": true,
             "license": "MIT",
@@ -12779,9 +12741,8 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-            "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+            "version": "5.49.0",
+            "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "peer": true,
@@ -12800,7 +12761,6 @@
         },
         "node_modules/terser/node_modules/source-map-support": {
             "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "license": "MIT",
@@ -14234,7 +14194,6 @@
         },
         "node_modules/watchpack": {
             "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
             "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
             "dev": true,
             "license": "MIT",
@@ -14267,9 +14226,8 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.108.2",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.2.tgz",
-            "integrity": "sha512-sUWBWPJwWH+QHUObS4lfNaQ368Tj8NaHDBsRJcU/NmQpeOqxV5iQUT2c5nvDWi8WYR5ynF7az+PuMdc+oDLJOA==",
+            "version": "5.108.4",
+            "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -14314,9 +14272,8 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
-            "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
+            "version": "3.5.1",
+            "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -14325,17 +14282,15 @@
             }
         },
         "node_modules/webpack/node_modules/es-module-lexer": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-            "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+            "version": "2.3.1",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
             "dev": true,
             "license": "MIT",
             "peer": true
         },
         "node_modules/webpack/node_modules/eslint-scope": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
             "dev": true,
             "license": "BSD-2-Clause",
             "peer": true,
@@ -14349,8 +14304,7 @@
         },
         "node_modules/webpack/node_modules/estraverse": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
             "dev": true,
             "license": "BSD-2-Clause",
             "peer": true,
@@ -14360,7 +14314,6 @@
         },
         "node_modules/webpack/node_modules/mime-db": {
             "version": "1.54.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
             "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
             "dev": true,
             "license": "MIT",
@@ -14698,7 +14651,7 @@
         },
         "projects/fdc3-web": {
             "name": "@morgan-stanley/fdc3-web",
-            "version": "0.15.0",
+            "version": "0.16.0",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@finos/fdc3": "^2.2.0"
@@ -14706,16 +14659,16 @@
         },
         "projects/messaging-provider": {
             "name": "@morgan-stanley/fdc3-web-messaging-provider",
-            "version": "0.15.0",
+            "version": "0.16.0",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@finos/fdc3": "^2.2.0",
-                "@morgan-stanley/fdc3-web": "^0.15.0"
+                "@morgan-stanley/fdc3-web": "^0.16.0"
             }
         },
         "projects/ui-provider": {
             "name": "@morgan-stanley/fdc3-web-ui-provider",
-            "version": "0.15.0",
+            "version": "0.16.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "lit": "^3.3.3",
@@ -14723,7 +14676,7 @@
             },
             "peerDependencies": {
                 "@finos/fdc3": "^2.2.0",
-                "@morgan-stanley/fdc3-web": "^0.15.0"
+                "@morgan-stanley/fdc3-web": "^0.16.0"
             }
         }
     }

--- a/projects/fdc3-web/package.json
+++ b/projects/fdc3-web/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "main": "index.js",
     "types": "index.d.ts",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "license": "Apache-2.0",
     "author": "Morgan Stanley",
     "repository": {

--- a/projects/fdc3-web/src/agent/desktop-agent.spec.ts
+++ b/projects/fdc3-web/src/agent/desktop-agent.spec.ts
@@ -40,6 +40,7 @@ import {
     DesktopAgentStrategies,
     EventMessage,
     FullyQualifiedAppIdentifier,
+    INewInstanceStrategy,
     IOpenApplicationStrategy,
     ISelectApplicationStrategy,
     RequestMessage,
@@ -127,6 +128,7 @@ describe(`${DesktopAgentImpl.name} (desktop-agent)`, () => {
             setupFunction('publishResponseMessage'),
             setupFunction('addResponseHandler'),
             setupProperty('requestMessageHandler'),
+            setupProperty('newInstanceHandler'),
             setupFunction('sendMessage'),
         );
 
@@ -290,6 +292,29 @@ describe(`${DesktopAgentImpl.name} (desktop-agent)`, () => {
         expect(instance).toBeDefined();
 
         expect(mockRootPublisher.withSetter('requestMessageHandler')).wasCalledOnce();
+        expect(mockRootPublisher.withSetter('newInstanceHandler')).wasCalledOnce();
+    });
+
+    it(`should notify any INewInstanceStrategy when rootMessagePublisher.newInstanceHandler is invoked`, async () => {
+        const mockNewInstanceStrategy = Mock.create<INewInstanceStrategy>().setup(setupFunction('onNewInstance'));
+
+        createInstance([mockNewInstanceStrategy.mock]);
+
+        const newInstanceHandler = mockRootPublisher.setterCallLookup.newInstanceHandler?.[0][0];
+
+        const mockAppWindow = Mock.create<Window>().mock;
+
+        newInstanceHandler?.({
+            window: mockAppWindow,
+            fullyQualifiedAppIdentifier: { appId: mockedTargetAppId, instanceId: mockedGeneratedUuid },
+        });
+
+        expect(
+            mockNewInstanceStrategy.withFunction('onNewInstance').withParametersEqualTo({
+                window: mockAppWindow,
+                fullyQualifiedAppIdentifier: { appId: mockedTargetAppId, instanceId: mockedGeneratedUuid },
+            }),
+        ).wasCalledOnce();
     });
 
     describe(`onMessage`, () => {

--- a/projects/fdc3-web/src/agent/desktop-agent.ts
+++ b/projects/fdc3-web/src/agent/desktop-agent.ts
@@ -39,6 +39,7 @@ import {
     FullyQualifiedAppIdentifier,
     IOpenApplicationStrategy,
     ISelectApplicationStrategy,
+    NewInstanceStrategyParams,
     RequestMessage,
 } from '../contracts.js';
 import {
@@ -56,6 +57,7 @@ import {
     isDefined,
     isFindInstancesErrors,
     isFullyQualifiedAppIdentifier,
+    isNewInstanceStrategy,
     isOpenApplicationStrategy,
     isOpenError,
     isResponsePayloadError,
@@ -119,6 +121,7 @@ export class DesktopAgentImpl extends DesktopAgentProxy implements DesktopAgentN
 
         this.rootMessagePublisher = params.rootMessagePublisher;
         params.rootMessagePublisher.requestMessageHandler = this.onRequestMessage.bind(this);
+        params.rootMessagePublisher.newInstanceHandler = this.notifyNewInstanceStrategies.bind(this);
         this.directory = params.directory;
         this.channelMessageHandler = params.channelFactory.createMessageHandler(this.rootMessagePublisher);
 
@@ -1097,6 +1100,17 @@ export class DesktopAgentImpl extends DesktopAgentProxy implements DesktopAgentN
                 source,
             );
         }
+    }
+
+    /**
+     * Informs any registered INewInstanceStrategy that a new instanceId has been assigned to an application.
+     * Invoked by rootMessagePublisher.newInstanceHandler once the handshake with the app instance completes,
+     * regardless of how the app's window was opened (FDC3 open() or the app opening/registering itself).
+     */
+    private notifyNewInstanceStrategies(params: NewInstanceStrategyParams): void {
+        this.applicationStrategies.filter(isNewInstanceStrategy).forEach(strategy => {
+            strategy.onNewInstance(params);
+        });
     }
 
     /**

--- a/projects/fdc3-web/src/contracts.ts
+++ b/projects/fdc3-web/src/contracts.ts
@@ -134,6 +134,11 @@ export interface IRootIncomingMessageEnvelope<
      * Indicates which channel (which maps to a given proxy agent) the message was received from
      */
     channelId: string;
+    /**
+     * The window of the app instance the message was received from, if known (e.g. captured from the
+     * WCP1Hello handshake). Used to notify INewInstanceStrategy once an instanceId has been assigned.
+     */
+    window?: Window;
 }
 
 /**
@@ -357,7 +362,28 @@ export type OpenApplicationStrategyResolverParams = ApplicationStrategyParams & 
     appReadyPromise: Promise<FullyQualifiedAppIdentifier>;
 };
 
-export type DesktopAgentStrategies = IOpenApplicationStrategy | ISelectApplicationStrategy;
+export type DesktopAgentStrategies = IOpenApplicationStrategy | ISelectApplicationStrategy | INewInstanceStrategy;
+
+export type NewInstanceStrategyParams = {
+    /**
+     * The window of the newly registered application instance, if known. This is populated from the window
+     * that completed the WCP1Hello/WCP4ValidateAppIdentity handshake, so it is available regardless of how the
+     * window was created (e.g. via an IOpenApplicationStrategy, `window.open()`, or an iframe that registers itself).
+     * It will be undefined if the app instance is not window-based (e.g. connects via a non-window transport).
+     */
+    window?: Window;
+    fullyQualifiedAppIdentifier: FullyQualifiedAppIdentifier;
+};
+
+/**
+ * Notified by the desktop agent whenever a new instanceId has been assigned to an application instance that has
+ * completed its connection handshake. Unlike IOpenApplicationStrategy/ISelectApplicationStrategy, this is invoked
+ * for every new instance regardless of how it was opened, so it can be used to track or manage windows that were
+ * not opened via an IOpenApplicationStrategy.
+ */
+export interface INewInstanceStrategy {
+    onNewInstance(params: NewInstanceStrategyParams): void;
+}
 
 /**
  * Replaces the default mechanism used to open new applications

--- a/projects/fdc3-web/src/helpers/type-predicate.helper.spec.ts
+++ b/projects/fdc3-web/src/helpers/type-predicate.helper.spec.ts
@@ -16,6 +16,7 @@ import {
     isFullyQualifiedAppId,
     isFullyQualifiedAppIdentifier,
     isIMSHostManifest,
+    isNewInstanceStrategy,
     isNonEmptyArray,
     isOpenApplicationStrategy,
     isSelectApplicationStrategy,
@@ -95,6 +96,15 @@ describe(`type-predicate.helper`, () => {
             { selectApp: () => Promise.resolve('uuid') },
             { canSelectApp: 'notAFunction', selectApp: () => Promise.resolve('uuid') },
             { canSelectApp: () => Promise.resolve(true), selectApp: 'notAFunction' },
+            { canOpen: () => Promise.resolve(true), open: () => Promise.resolve('uuid') },
+        ],
+    );
+
+    testTypePredicate(
+        isNewInstanceStrategy,
+        [{ onNewInstance: () => {} }],
+        [
+            { onNewInstance: 'notAFunction' },
             { canOpen: () => Promise.resolve(true), open: () => Promise.resolve('uuid') },
         ],
     );

--- a/projects/fdc3-web/src/helpers/type-predicate.helper.ts
+++ b/projects/fdc3-web/src/helpers/type-predicate.helper.ts
@@ -13,6 +13,7 @@ import { IMSHostManifest, WebAppDetails } from '../app-directory.contracts.js';
 import {
     FullyQualifiedAppId,
     FullyQualifiedAppIdentifier,
+    INewInstanceStrategy,
     IOpenApplicationStrategy,
     IRootOutgoingMessageEnvelope,
     ISelectApplicationStrategy,
@@ -89,6 +90,15 @@ export function isSelectApplicationStrategy(value: any): value is ISelectApplica
     const strategy = value as ISelectApplicationStrategy;
 
     return strategy != null && typeof strategy.canSelectApp === 'function' && typeof strategy.selectApp === 'function';
+}
+
+/**
+ * type predicate to determine if a strategy is an INewInstanceStrategy
+ */
+export function isNewInstanceStrategy(value: any): value is INewInstanceStrategy {
+    const strategy = value as INewInstanceStrategy;
+
+    return strategy != null && typeof strategy.onNewInstance === 'function';
 }
 
 export function isDefined<T>(value: T | null | undefined): value is T {

--- a/projects/fdc3-web/src/messaging-provider/default-root-messaging-provider.spec.ts
+++ b/projects/fdc3-web/src/messaging-provider/default-root-messaging-provider.spec.ts
@@ -129,6 +129,7 @@ describe('DefaultRootMessagingProvider', () => {
                 type: 'getInfoRequest',
             },
             channelId: mockedGeneratedUuid,
+            window: mockProxyWindow.mock,
         };
 
         (

--- a/projects/fdc3-web/src/messaging-provider/default-root-messaging-provider.ts
+++ b/projects/fdc3-web/src/messaging-provider/default-root-messaging-provider.ts
@@ -25,6 +25,9 @@ import { generateHandshakeResponseMessage, generateUUID, isWCPHelloMessage } fro
 export class DefaultRootMessagingProvider implements IRootMessagingProvider {
     private callbacks: IncomingMessageCallback<IRootIncomingMessageEnvelope>[] = [];
     private messageChannels: Record<string, MessagePort> = {};
+    //tracks the window each channel's app connected from, captured from the WCP1Hello handshake, so it can be
+    //passed on to callbacks (and ultimately to any INewInstanceStrategy) once the app's instanceId is known
+    private windowsByChannelId: Record<string, Window> = {};
 
     constructor(
         windowRef: Window,
@@ -73,7 +76,7 @@ export class DefaultRootMessagingProvider implements IRootMessagingProvider {
             // listen to incoming messages on the new channel
             messageChannel.port1.addEventListener('message', message => {
                 for (const callback of this.callbacks) {
-                    callback({ payload: message.data, channelId });
+                    callback({ payload: message.data, channelId, window: this.windowsByChannelId[channelId] });
                 }
             });
 
@@ -82,6 +85,8 @@ export class DefaultRootMessagingProvider implements IRootMessagingProvider {
             const response = generateHandshakeResponseMessage(message.data);
 
             if (sourceWindow != null) {
+                this.windowsByChannelId[channelId] = sourceWindow as Window;
+
                 // return response to the source app with the message  port to allow further communication over the message channel
                 sourceWindow.postMessage(response, { targetOrigin: '*', transfer: [messageChannel.port2] });
             } else {

--- a/projects/fdc3-web/src/messaging/root-message-publisher.spec.ts
+++ b/projects/fdc3-web/src/messaging/root-message-publisher.spec.ts
@@ -26,6 +26,7 @@ import {
     IncomingMessageCallback,
     IProxyIncomingMessageEnvelope,
     IRootMessagingProvider,
+    NewInstanceStrategyParams,
     RequestMessage,
 } from '../contracts.js';
 import * as helpersImport from '../helpers/index.js';
@@ -258,6 +259,90 @@ describe('RootMessagePublisher', () => {
 
             expect(
                 mockRequestHandler.withFunction('handler').withParametersEqualTo(requestMessage, sourceApp),
+            ).wasCalledOnce();
+        });
+    });
+
+    describe('newInstanceHandler', () => {
+        it('should notify newInstanceHandler with the window captured from the handshake once a new instance is registered', async () => {
+            const instance = createInstance();
+
+            const mockNewInstanceHandler = Mock.create<{
+                handler: (params: NewInstanceStrategyParams) => void;
+            }>().setup(setupFunction('handler'));
+
+            instance.newInstanceHandler = mockNewInstanceHandler.mock.handler;
+
+            const sourceApp: FullyQualifiedAppIdentifier = {
+                appId: sourceAppId,
+                instanceId: 'instanceOne',
+            };
+
+            generateUuidResult = sourceApp.instanceId;
+            mockDirectory.setupFunction('registerNewInstance', () => {
+                return Promise.resolve({
+                    application: Mock.create<AppDirectoryApplication>().setup(setupProperty('appId', sourceApp.appId))
+                        .mock,
+                    identifier: sourceApp,
+                });
+            });
+
+            const mockAppWindow = Mock.create<Window>().mock;
+            const validationMessage = createValidationRequestMessage();
+
+            mockRootMessagingProvider.functionCallLookup.subscribe?.[0][0]({
+                payload: validationMessage,
+                channelId: 'channelOne',
+                window: mockAppWindow,
+            });
+
+            await waitForMessage(message => message.payload.type === 'WCP5ValidateAppIdentityResponse');
+
+            expect(
+                mockNewInstanceHandler.withFunction('handler').withParametersEqualTo({
+                    window: mockAppWindow,
+                    fullyQualifiedAppIdentifier: sourceApp,
+                }),
+            ).wasCalledOnce();
+        });
+
+        it('should notify newInstanceHandler with an undefined window when none was captured', async () => {
+            const instance = createInstance();
+
+            const mockNewInstanceHandler = Mock.create<{
+                handler: (params: NewInstanceStrategyParams) => void;
+            }>().setup(setupFunction('handler'));
+
+            instance.newInstanceHandler = mockNewInstanceHandler.mock.handler;
+
+            const sourceApp: FullyQualifiedAppIdentifier = {
+                appId: sourceAppId,
+                instanceId: 'instanceTwo',
+            };
+
+            generateUuidResult = sourceApp.instanceId;
+            mockDirectory.setupFunction('registerNewInstance', () => {
+                return Promise.resolve({
+                    application: Mock.create<AppDirectoryApplication>().setup(setupProperty('appId', sourceApp.appId))
+                        .mock,
+                    identifier: sourceApp,
+                });
+            });
+
+            const validationMessage = createValidationRequestMessage();
+
+            mockRootMessagingProvider.functionCallLookup.subscribe?.[0][0]({
+                payload: validationMessage,
+                channelId: 'channelTwo',
+            });
+
+            await waitForMessage(message => message.payload.type === 'WCP5ValidateAppIdentityResponse');
+
+            expect(
+                mockNewInstanceHandler.withFunction('handler').withParametersEqualTo({
+                    window: undefined,
+                    fullyQualifiedAppIdentifier: sourceApp,
+                }),
             ).wasCalledOnce();
         });
     });

--- a/projects/fdc3-web/src/messaging/root-message-publisher.ts
+++ b/projects/fdc3-web/src/messaging/root-message-publisher.ts
@@ -20,6 +20,7 @@ import {
     IProxyOutgoingMessageEnvelope,
     IRootIncomingMessageEnvelope,
     IRootMessagingProvider,
+    NewInstanceStrategyParams,
     RequestMessage,
     ResponseMessage,
 } from '../contracts.js';
@@ -53,6 +54,12 @@ export class RootMessagePublisher implements IRootPublisher {
      * Used for passing requests from incoming messages received from proxy agents (or from the root agent itself) to the request handler function in desktop-agent
      */
     public requestMessageHandler: RequestMessageHandler | undefined;
+
+    /**
+     * Called whenever a new instanceId has been assigned to an app instance completing the handshake, so that
+     * any registered INewInstanceStrategy can be notified (along with the window it connected from, if known)
+     */
+    public newInstanceHandler: ((params: NewInstanceStrategyParams) => void) | undefined;
 
     /**
      * Used for loopback response messages that the desktop-agent has published but that need to be returned to the proxy-agent code (which desktop-agent extends)
@@ -179,7 +186,7 @@ export class RootMessagePublisher implements IRootPublisher {
         >,
     ): void {
         if (isWCPValidateAppIdentity(message.payload)) {
-            this.registerNewInstance(message.payload, message.channelId);
+            this.registerNewInstance(message.payload, message.channelId, message.window);
             return;
         }
 
@@ -226,6 +233,7 @@ export class RootMessagePublisher implements IRootPublisher {
     private async registerNewInstance(
         validateMessage: BrowserTypes.WebConnectionProtocol4ValidateAppIdentity,
         channelId: string,
+        window: Window | undefined,
     ): Promise<FullyQualifiedAppIdentifier | undefined> {
         this.log('Registering new instance', LogLevel.DEBUG, { validateMessage, channelId });
 
@@ -239,6 +247,8 @@ export class RootMessagePublisher implements IRootPublisher {
 
         this.channelIdToAppIdentifier[channelId] = identifier;
         this.instanceIdToChannelId[identifier.instanceId] = channelId;
+
+        this.newInstanceHandler?.({ window, fullyQualifiedAppIdentifier: identifier });
 
         const response: BrowserTypes.WebConnectionProtocol5ValidateAppIdentitySuccessResponse = {
             type: 'WCP5ValidateAppIdentityResponse',

--- a/projects/messaging-provider/package.json
+++ b/projects/messaging-provider/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "types": "index.d.ts",
     "type": "module",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "license": "Apache-2.0",
     "author": "Morgan Stanley",
     "repository": {
@@ -11,7 +11,7 @@
         "url": "https://github.com/morganstanley/fdc3-web"
     },
     "peerDependencies": {
-        "@morgan-stanley/fdc3-web": "^0.15.0",
+        "@morgan-stanley/fdc3-web": "^0.16.0",
         "@finos/fdc3": "^2.2.0"
     }
 }

--- a/projects/ui-provider/package.json
+++ b/projects/ui-provider/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "main": "index.js",
     "types": "index.d.ts",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "license": "Apache-2.0",
     "author": "Morgan Stanley",
     "repository": {
@@ -11,7 +11,7 @@
         "url": "https://github.com/morganstanley/fdc3-web"
     },
     "peerDependencies": {
-        "@morgan-stanley/fdc3-web": "^0.15.0",
+        "@morgan-stanley/fdc3-web": "^0.16.0",
         "@finos/fdc3": "^2.2.0"
     },
     "dependencies": {


### PR DESCRIPTION
Adds support for a new strategy: `INewInstanceStrategy` that allows the top level container to be informed by the Desktop Agent whenver a new application instance is registered. The strategy is passed the fully qualified app identifier and the window that the application is hosted in. 
This can be used for identifying the identity of an application that you have just opened in an iframe or a new window for example and also allows control of the new window for focussing or closing for example.